### PR TITLE
chore: enforce LF line endings via .gitattributes eol=lf

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
-# Auto detect text files and perform LF normalization
-* text=auto
+# Enforce LF line endings in both index and working copy
+* text=auto eol=lf


### PR DESCRIPTION
Prevents Windows core.autocrlf from converting files to CRLF on checkout, which was showing all tracked files as modified with no real content changes.