### PR TITLE
chore: add AdSense ads.txt at apex domain

### DIFF
--- a/public/ads.txt
+++ b/public/ads.txt
@@ -1,0 +1,1 @@
+google.com, pub-4628379278051632, DIRECT, f08c47fec0942fa0


### PR DESCRIPTION
## Summary
- Adds `public/ads.txt` with the AdSense publisher line so it serves at the apex domain root.

## Why
AdSense only reads ads.txt at the root domain — the copy on the instrument tuner subdomain is invisible to the crawler. This file authorizes ads served on the subdomain and doubles as AdSense site-ownership verification for the root domain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)