### PR TITLE
feat(errors): root error boundary and RouteErrorFallback global-error

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,13 @@ All other workspace DoD items remain required.
 
 ---
 
+## Error Boundaries
+
+- Root (`src/app/error.tsx`) and global (`src/app/global-error.tsx`) boundaries render `RouteErrorFallback` (`@crawfordyoung/ui` ≥0.24.0) with `homeHref="/"` — placement rule: root/global boundaries get the home link (no surviving shell nav); segment boundaries would not.
+- Both capture to Sentry via `useEffect(() => Sentry.captureException(error), [error])`.
+- `src/app/**` is excluded from the vitest coverage `include` allowlist — `tests/unit/root-error.test.tsx` and `tests/unit/global-error.test.tsx` are behavioral, not coverage-feeding.
+- **Known tooling gap:** `postcss.config.mjs` uses the Next.js/Tailwind-v4 string-plugin form (`plugins: ['@tailwindcss/postcss']`), which Vite's own postcss loader (used by vitest) cannot resolve — any test that transitively imports a `.css` file fails with `Invalid PostCSS Plugin found`. `global-error.tsx` imports `@/app/globals.css` so design tokens resolve outside the app shell; its test mocks that import (`vi.mock('@/app/globals.css', () => ({}))`) to route around the gap. A real fix (postcss config format vitest can also load, or a vitest CSS alias) is unscoped housekeeping — not fixed here.
+
 ## Deployment
 
 - Deployed automatically on push to `main` via Vercel

--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ You can start editing the page by modifying `app/page.tsx`. The page auto-update
 
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
 
+## Error Boundaries
+
+- `src/app/error.tsx` (root boundary) and `src/app/global-error.tsx` (global boundary, catches errors in the root layout itself) both render `RouteErrorFallback` from `@crawfordyoung/ui` with `homeHref="/"` — a home link is the only surviving nav at these two levels since the app shell may not have rendered.
+- Both boundaries capture the error to Sentry (`@sentry/nextjs`) via a `useEffect`.
+- Segment-level boundaries (none currently in this repo) keep the app shell and do not need `homeHref` — the shell nav already gets the user home.
+
 ## Learn More
 
 To learn more about Next.js, take a look at the following resources:

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     ]
   },
   "dependencies": {
-    "@crawfordyoung/ui": "^0.22.0",
+    "@crawfordyoung/ui": "^0.24.0",
     "@sentry/nextjs": "^10.49.0",
     "@vercel/analytics": "^2.0.1",
     "@vercel/speed-insights": "^2.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,8 +20,8 @@ importers:
   .:
     dependencies:
       '@crawfordyoung/ui':
-        specifier: ^0.22.0
-        version: 0.22.0(@tanstack/react-table@8.21.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(cmdk@1.1.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(date-fns@4.4.0)(framer-motion@12.38.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(lucide-react@0.511.0(react@19.1.0))(react-day-picker@10.0.1(@types/react@19.2.14)(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-is@17.0.2)(react@19.1.0)(redux@5.0.1)(sonner@2.0.7(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(tailwindcss-animate@1.0.7(tailwindcss@4.2.2))(tailwindcss@4.2.2)
+        specifier: ^0.24.0
+        version: 0.24.0(@tanstack/react-table@8.21.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(cmdk@1.1.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(date-fns@4.4.0)(framer-motion@12.38.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(lucide-react@0.511.0(react@19.1.0))(react-day-picker@10.0.1(@types/react@19.2.14)(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-is@17.0.2)(react@19.1.0)(redux@5.0.1)(sonner@2.0.7(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(tailwindcss-animate@1.0.7(tailwindcss@4.2.2))(tailwindcss@4.2.2)
       '@sentry/nextjs':
         specifier: ^10.49.0
         version: 10.56.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(next@16.2.7(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)(webpack@5.107.2(lightningcss@1.32.0))
@@ -334,8 +334,8 @@ packages:
       conventional-commits-parser:
         optional: true
 
-  '@crawfordyoung/ui@0.22.0':
-    resolution: {integrity: sha512-oyhluUFgNjmt2UAzfxPZM3ophGCOcSnAKWKQPeJeSkeruGliY8LibTyGdzrT2YG2/rW4gNgLe5kj5CT2t4VBAw==}
+  '@crawfordyoung/ui@0.24.0':
+    resolution: {integrity: sha512-gr210fAADflbiN5vNdxwRqEzg2E/44IVlbm9z5PREOftR/XDwbWvQ1ouIzW6vKURgQV46e7bhEYaG682kMNt5Q==}
     peerDependencies:
       '@tanstack/react-table': '>=8'
       cmdk: '>=1'
@@ -4933,7 +4933,7 @@ snapshots:
     optionalDependencies:
       conventional-commits-parser: 6.4.0
 
-  '@crawfordyoung/ui@0.22.0(@tanstack/react-table@8.21.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(cmdk@1.1.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(date-fns@4.4.0)(framer-motion@12.38.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(lucide-react@0.511.0(react@19.1.0))(react-day-picker@10.0.1(@types/react@19.2.14)(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-is@17.0.2)(react@19.1.0)(redux@5.0.1)(sonner@2.0.7(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(tailwindcss-animate@1.0.7(tailwindcss@4.2.2))(tailwindcss@4.2.2)':
+  '@crawfordyoung/ui@0.24.0(@tanstack/react-table@8.21.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(cmdk@1.1.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(date-fns@4.4.0)(framer-motion@12.38.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(lucide-react@0.511.0(react@19.1.0))(react-day-picker@10.0.1(@types/react@19.2.14)(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-is@17.0.2)(react@19.1.0)(redux@5.0.1)(sonner@2.0.7(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(tailwindcss-animate@1.0.7(tailwindcss@4.2.2))(tailwindcss@4.2.2)':
     dependencies:
       '@radix-ui/react-accordion': 1.2.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@radix-ui/react-alert-dialog': 1.1.19(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -4954,7 +4954,7 @@ snapshots:
       '@radix-ui/react-select': 2.3.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@radix-ui/react-separator': 1.1.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@radix-ui/react-slider': 1.4.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@radix-ui/react-slot': 1.2.4(@types/react@19.2.14)(react@19.1.0)
+      '@radix-ui/react-slot': 1.3.0(@types/react@19.2.14)(react@19.1.0)
       '@radix-ui/react-switch': 1.3.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@radix-ui/react-tabs': 1.1.17(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@radix-ui/react-toggle': 1.1.14(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -7079,10 +7079,10 @@ snapshots:
 
   cmdk@1.1.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.1.0)
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.14)(react@19.1.0)
       '@radix-ui/react-dialog': 1.1.19(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@radix-ui/react-id': 1.1.2(@types/react@19.2.14)(react@19.1.0)
-      '@radix-ui/react-primitive': 2.1.4(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
     transitivePeerDependencies:

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,11 +1,10 @@
 'use client'
 
-import '@/app/globals.css'
 import * as Sentry from '@sentry/nextjs'
 import { RouteErrorFallback } from '@/lib/ui'
 import { useEffect } from 'react'
 
-export default function GlobalError({
+export default function RootError({
   error,
   reset,
 }: {
@@ -16,11 +15,5 @@ export default function GlobalError({
     Sentry.captureException(error)
   }, [error])
 
-  return (
-    <html lang="en" className="dark">
-      <body className="flex min-h-screen items-center justify-center">
-        <RouteErrorFallback error={error} reset={reset} homeHref="/" />
-      </body>
-    </html>
-  )
+  return <RouteErrorFallback error={error} reset={reset} homeHref="/" />
 }

--- a/tests/unit/global-error.test.tsx
+++ b/tests/unit/global-error.test.tsx
@@ -1,0 +1,29 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/app/globals.css', () => ({}))
+vi.mock('@sentry/nextjs', () => ({ captureException: vi.fn() }))
+
+import GlobalError from '@/app/global-error'
+import * as Sentry from '@sentry/nextjs'
+
+function makeError(): Error & { digest?: string } {
+  return Object.assign(new Error('boom'), { digest: 'abc123' })
+}
+
+describe('GlobalError', () => {
+  it('renders fallback with home link and captures to Sentry', () => {
+    const error = makeError()
+    render(<GlobalError error={error} reset={() => {}} />)
+    expect(screen.getByText('Something went wrong')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Go home' })).toHaveAttribute('href', '/')
+    expect(vi.mocked(Sentry.captureException)).toHaveBeenCalledWith(error)
+  })
+
+  it('invokes reset on retry click', () => {
+    const reset = vi.fn()
+    render(<GlobalError error={makeError()} reset={reset} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Try again' }))
+    expect(reset).toHaveBeenCalledOnce()
+  })
+})

--- a/tests/unit/root-error.test.tsx
+++ b/tests/unit/root-error.test.tsx
@@ -1,0 +1,27 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import RootError from '@/app/error'
+
+vi.mock('@sentry/nextjs', () => ({ captureException: vi.fn() }))
+import * as Sentry from '@sentry/nextjs'
+
+function makeError(): Error & { digest?: string } {
+  return Object.assign(new Error('boom'), { digest: 'abc123' })
+}
+
+describe('RootError', () => {
+  it('renders fallback with home link and captures to Sentry', () => {
+    const error = makeError()
+    render(<RootError error={error} reset={() => {}} />)
+    expect(screen.getByText('Something went wrong')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Go home' })).toHaveAttribute('href', '/')
+    expect(vi.mocked(Sentry.captureException)).toHaveBeenCalledWith(error)
+  })
+
+  it('invokes reset on retry click', () => {
+    const reset = vi.fn()
+    render(<RootError error={makeError()} reset={reset} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Try again' }))
+    expect(reset).toHaveBeenCalledOnce()
+  })
+})


### PR DESCRIPTION
## Summary

- Bump `@crawfordyoung/ui` `^0.22.0` → `^0.24.0`
- New `app/error.tsx` — canonical `RouteErrorFallback` + Sentry capture, `homeHref="/"`
- `app/global-error.tsx` rewritten: Sentry-generated `NextError statusCode={0}` boilerplate → library-styled `RouteErrorFallback` (Sentry capture kept, missing `reset` param added, own `<html className="dark">`/`<body>` with `globals.css` import)
- Root/global boundaries strand the user → both get the home link

## Testing

- `PORT=3010 just check` EXIT:0 (lint + typecheck + test + build + e2e 8/8)
- Coverage baseline 100/100/100/100 (`src/app/**` outside the coverage allowlist by design)
- 4 new boundary tests; Sentry mocked, captureException asserted
- Known tooling gap documented in CLAUDE.md: vitest's Vite postcss loader can't parse the string-form `postcss.config.mjs` plugin — global-error test mocks `globals.css` (pre-existing gap, probe-proven, adjudicated sound in review)
- Combined review: zero findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)
