### PR TITLE
feat: writing surface, project write-ups, and about page (adsense-w3)

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -4,3 +4,5 @@ coverage
 pnpm-lock.yaml
 playwright-report
 test-results
+# Prose content — poem line breaks are content, and prettier's MDX parser is experimental
+src/content

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,6 +83,15 @@ All other workspace DoD items remain required.
 - **`tests/e2e/compliance.spec.ts` runs against a configurable base URL** — `PORT` for local, `E2E_BASE_URL` for production. Nine tests: `ads.txt` (200, `text/plain`, publisher line byte-exact), `robots.txt` (200, carries `Sitemap:`), `sitemap.xml` (200, lists `/privacy`), the `/privacy` and `/contact` headings, `og:url === SITE_URL`, the verification meta tag asserted against the RAW response body (a rendered-DOM check would pass on the loader alone), the debug routes 404ing, and a real 404 on an unknown path. **The `just check` e2e recipe passes no `PORT`**, and `reuseExistingServer: !CI` will silently drive whatever dev server already holds the port — run the e2e segment as `PORT=<own port> pnpm exec playwright test` whenever another session is live.
 - **No Sentry debug routes.** `/sentry-example-page` and its API route were removed — crawlable, contentless, and deliberately error-throwing. Don't reintroduce them; test Sentry from a scratch branch.
 
+## Writing & MDX Conventions (adsense-w3)
+
+- **Add-a-piece triple:** every piece of prose is (1) a registry entry in `src/data/writing.ts` (zod-validated; poems carry anchor slugs), (2) an `.mdx` file under `src/content/` (`writing/<slug>.mdx`, `projects/<slug>.mdx`, or `about.mdx`), and (3) an explicit `import()` line in the matching content map (`src/app/writing/content-map.ts` or `src/app/projects/[slug]/content-map.ts` — named export `projectContent`). Explicit imports are load-bearing: Turbopack cannot follow template-literal dynamic imports. Miss the registry or leave a stray file and the orphan-file check in `tests/unit/writing-content.test.ts` fails.
+- **Word-count floors** live in `src/lib/writing-content.ts`: `COLLECTION_MIN_WORDS=400`, `STORY_MIN_WORDS=800`, `PROJECT_MIN_WORDS=300`, `ABOUT_MIN_WORDS=350`. They exist for AdSense's substantive-content bar — don't lower them to make a thin piece pass; write more.
+- **No MDX in vitest.** The unit tests compile RAW `.mdx` source via `@mdx-js/mdx`'s `compile()` — they never import an `.mdx` module, because vitest has no MDX plugin and an import would fail on syntax, not content. Rendering is e2e's job (`tests/e2e/writing.spec.ts`).
+- **`src/content/` is prettier-ignored** (see `.prettierignore`): poem line/stanza breaks are content, and prettier's MDX parser is experimental — a format pass would rewrite meaning.
+- **Per-page canonical unit:** every content page exports `alternates.canonical` plus a full `openGraph` block (`url`, `siteName: 'Crawford Young'`, `type: 'article'` for pieces / `'website'` for hubs / `'profile'` for about). `metadataBase` alone emits nothing — the W1 rule above applies per page, not just at the root.
+- **Turbopack dev-server MDX first-compile race:** concurrent first requests to MDX routes can 500 one of them ("Unexpected end of JSON input") — dev-only; prod prerenders all routes. Local playwright `retries: 1` absorbs it (a retried test runs alone); a failure that survives the retry is real. Same class as instrumenttuner's guide pages.
+
 ## Deployment
 
 - Deployed automatically on push to `main` via Vercel

--- a/README.md
+++ b/README.md
@@ -9,8 +9,23 @@ Live at **https://crawfordyoung.dev**.
 - **Home** (`src/app/page.tsx`): Hero (pitch H1 "I build AI products and developer tools.", avatar eyebrow, "Try Cybond" + GitHub CTAs) → three full-width `FlagshipSection`s with alternating screenshot sides (`@crawfordyoung/ui`, Cybond, Cy's Music) → "More projects" grid (`ProjectCard`) → "About the builder" bento strip (About / Hobbies teaser / GitHub stats / Contact, `id="contact"` anchor).
 - **Projects page**: flagships first (full-width, pitch copy via `ProjectCard`'s `featured` prop), then the rest in a 2-column grid.
 - **Hobbies page**: per-hobby `Accordion` (single-open, from `@crawfordyoung/ui`) replacing the old expandable cards.
+- **Writing hub** (`src/app/writing/`): `/writing` lists three poem collections and one short story; each piece lives at `/writing/<slug>` with per-poem anchor links. Content is MDX — see [Writing & content pipeline](#writing--content-pipeline).
+- **About page** (`src/app/about/`): ~400-word first-person bio rendered from `src/content/about.mdx`, linked last in the nav.
+- **Project detail pages** (`src/app/projects/[slug]/`): each project carries a 300–600-word MDX write-up (problem → approach → what I'd do differently → what broke) rendered below the CTA row.
 - **Privacy page** (`src/app/privacy/page.tsx`) and **Contact page** (`src/app/contact/page.tsx`): the two AdSense-required legal/contact surfaces, linked from the footer. Contact publishes `hello@crawfordyoung.dev`.
 - **Crawlability surfaces**: `src/app/robots.ts` and `src/app/sitemap.ts` are thin wrappers over `src/lib/site-routes.ts` (which owns `SITE_URL` and the route list — logic lives in `src/lib/` because `src/app/**` is outside the vitest coverage allowlist). `public/ads.txt` carries the AdSense publisher line. `tests/e2e/compliance.spec.ts` asserts the whole contract — `ads.txt`, `robots.txt`, `sitemap.xml`, the legal page, a real 404 on an unknown path — against a configurable base URL (`PORT` / `E2E_BASE_URL`), so the same spec runs against dev in the gate and against production after deploy. The Sentry debug routes were removed: they were crawlable, contentless, and deliberately error-throwing.
+
+### Writing & content pipeline
+
+All long-form prose is MDX compiled by `@next/mdx`. The moving parts:
+
+- **Registry** — `src/data/writing.ts` (zod-validated): collections, poems (with anchor slugs), and the story. The hub, collection pages, sitemap, and content tests all derive from it.
+- **Content** — `src/content/writing/<slug>.mdx` (collections + story), `src/content/projects/<slug>.mdx` (project write-ups), `src/content/about.mdx`.
+- **Content maps** — `src/app/writing/content-map.ts` and `src/app/projects/[slug]/content-map.ts` hold explicit static `import()` entries per slug (Turbopack cannot follow template-literal dynamic imports).
+
+**Adding a piece** = registry entry + `.mdx` file + content-map line. The unit tests in `tests/unit/writing-content.test.ts` are registry-driven: they compile each raw MDX source via `@mdx-js/mdx` and enforce word-count floors (collections 400, story 800, project write-ups 300, about 350), plus an orphan-file check — a forgotten registry entry or stray `.mdx` fails the suite.
+
+`src/content/` is prettier-ignored: poem line breaks are content, and prettier's MDX parser is experimental.
 
 ### Project data model
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,4 +1,5 @@
 import { withSentryConfig } from '@sentry/nextjs'
+import createMDX from '@next/mdx'
 import type { NextConfig } from 'next'
 
 const securityHeaders = [
@@ -26,12 +27,15 @@ const securityHeaders = [
 ]
 
 const nextConfig: NextConfig = {
+  pageExtensions: ['ts', 'tsx', 'mdx'],
   async headers() {
     return [{ source: '/(.*)', headers: securityHeaders }]
   },
 }
 
-export default withSentryConfig(nextConfig, {
+const withMDX = createMDX({})
+
+export default withSentryConfig(withMDX(nextConfig), {
   // For all available options, see:
   // https://www.npmjs.com/package/@sentry/webpack-plugin#options
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
   },
   "dependencies": {
     "@crawfordyoung/ui": "^0.24.0",
+    "@mdx-js/loader": "^3.1.1",
+    "@mdx-js/react": "^3.1.1",
+    "@next/mdx": "^16.2.12",
     "@sentry/nextjs": "^10.49.0",
     "@vercel/analytics": "^2.0.1",
     "@vercel/speed-insights": "^2.0.0",
@@ -33,7 +36,8 @@
     "next-themes": "^0.4.6",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "tailwind-merge": "^3.3.0"
+    "tailwind-merge": "^3.3.0",
+    "zod": "^4.4.3"
   },
   "pnpm": {
     "overrides": {
@@ -54,11 +58,13 @@
     "@commitlint/config-conventional": "^20.5.0",
     "@commitlint/types": "^20.5.0",
     "@eslint/eslintrc": "^3",
+    "@mdx-js/mdx": "^3.1.1",
     "@playwright/test": "^1.60.0",
     "@tailwindcss/postcss": "^4",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.5.2",
+    "@types/mdx": "^2.0.14",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -10,7 +10,11 @@ export default defineConfig({
   testDir: './tests/e2e',
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
-  retries: process.env.CI ? 2 : 0,
+  // Local retry absorbs the Turbopack dev-server race on concurrent MDX first-compiles
+  // (random project/writing route 500s "Unexpected end of JSON input"; prod prerenders all
+  // routes fine — same class as instrumenttuner's guide pages). A retried test runs alone,
+  // which is the condition under which the compile succeeds; failing the retry is real.
+  retries: process.env.CI ? 2 : 1,
   workers: process.env.CI ? 1 : undefined,
   reporter: 'html',
   use: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,15 @@ importers:
       '@crawfordyoung/ui':
         specifier: ^0.24.0
         version: 0.24.0(@tanstack/react-table@8.21.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(cmdk@1.1.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(date-fns@4.4.0)(framer-motion@12.38.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(lucide-react@0.511.0(react@19.1.0))(react-day-picker@10.0.1(@types/react@19.2.14)(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-is@17.0.2)(react@19.1.0)(redux@5.0.1)(sonner@2.0.7(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(tailwindcss-animate@1.0.7(tailwindcss@4.2.2))(tailwindcss@4.2.2)
+      '@mdx-js/loader':
+        specifier: ^3.1.1
+        version: 3.1.1(webpack@5.107.2(lightningcss@1.32.0))
+      '@mdx-js/react':
+        specifier: ^3.1.1
+        version: 3.1.1(@types/react@19.2.14)(react@19.1.0)
+      '@next/mdx':
+        specifier: ^16.2.12
+        version: 16.2.12(@mdx-js/loader@3.1.1(webpack@5.107.2(lightningcss@1.32.0)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.1.0))
       '@sentry/nextjs':
         specifier: ^10.49.0
         version: 10.56.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@20.19.39)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)(webpack@5.107.2(lightningcss@1.32.0))
@@ -59,6 +68,9 @@ importers:
       tailwind-merge:
         specifier: ^3.3.0
         version: 3.5.0
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@commitlint/cli':
         specifier: ^20.5.0
@@ -72,6 +84,9 @@ importers:
       '@eslint/eslintrc':
         specifier: ^3
         version: 3.3.5
+      '@mdx-js/mdx':
+        specifier: ^3.1.1
+        version: 3.1.1
       '@playwright/test':
         specifier: ^1.60.0
         version: 1.60.0
@@ -87,6 +102,9 @@ importers:
       '@testing-library/user-event':
         specifier: ^14.5.2
         version: 14.6.1(@testing-library/dom@10.4.1)
+      '@types/mdx':
+        specifier: ^2.0.14
+        version: 2.0.14
       '@types/node':
         specifier: ^20
         version: 20.19.39
@@ -771,6 +789,23 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@mdx-js/loader@3.1.1':
+    resolution: {integrity: sha512-0TTacJyZ9mDmY+VefuthVshaNIyCGZHJG2fMnGaDttCt8HmjUF7SizlHJpaCDoGnN635nK1wpzfpx/Xx5S4WnQ==}
+    peerDependencies:
+      webpack: '>=5'
+    peerDependenciesMeta:
+      webpack:
+        optional: true
+
+  '@mdx-js/mdx@3.1.1':
+    resolution: {integrity: sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==}
+
+  '@mdx-js/react@3.1.1':
+    resolution: {integrity: sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw==}
+    peerDependencies:
+      '@types/react': '>=16'
+      react: '>=16'
+
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
 
@@ -779,6 +814,17 @@ packages:
 
   '@next/eslint-plugin-next@15.5.2':
     resolution: {integrity: sha512-lkLrRVxcftuOsJNhWatf1P2hNVfh98k/omQHrCEPPriUypR6RcS13IvLdIrEvkm9AH2Nu2YpR5vLqBuy6twH3Q==}
+
+  '@next/mdx@16.2.12':
+    resolution: {integrity: sha512-bbKvq/7SIJZgQFRYL3wwnzLwCBviQfWi5UR61RDWwaMX3fV6iSqKfVr5SErRNA/PhMer/ylvErX4SVaGNrwKcw==}
+    peerDependencies:
+      '@mdx-js/loader': '>=0.15.0'
+      '@mdx-js/react': '>=0.15.0'
+    peerDependenciesMeta:
+      '@mdx-js/loader':
+        optional: true
+      '@mdx-js/react':
+        optional: true
 
   '@next/swc-darwin-arm64@16.2.11':
     resolution: {integrity: sha512-wryL4pjKmDwGv2ox6+GZDFxvmtSRLqApBR8kL1j4+vhB7Z5vJC/zAnXpiR9Xkfzl0AS8WLMnsuGV/UKI67/rrw==}
@@ -2066,8 +2112,14 @@ packages:
   '@types/d3-timer@3.0.2':
     resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
 
+  '@types/debug@4.1.13':
+    resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree-jsx@1.0.5':
+    resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
@@ -2075,11 +2127,23 @@ packages:
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
+  '@types/hast@3.0.5':
+    resolution: {integrity: sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==}
+
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
+
+  '@types/mdast@4.0.4':
+    resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
+
+  '@types/mdx@2.0.14':
+    resolution: {integrity: sha512-T48PeuJtvLosNTPVhfnIp3i/n3a4g4Bad7YCq5k64D4u7NwDrAotikQ+5+sjtUvBmxCMlbo3dVL+C2dP0rWHzg==}
+
+  '@types/ms@2.1.0':
+    resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
   '@types/node@20.19.39':
     resolution: {integrity: sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==}
@@ -2091,6 +2155,12 @@ packages:
 
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
+
+  '@types/unist@2.0.11':
+    resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
+
+  '@types/unist@3.0.3':
+    resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
   '@types/use-sync-external-store@0.0.6':
     resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
@@ -2159,6 +2229,9 @@ packages:
   '@typescript-eslint/visitor-keys@8.58.2':
     resolution: {integrity: sha512-f1WO2Lx8a9t8DARmcWAUPJbu0G20bJlj8L4z72K00TMeJAoyLr/tHhI/pzYBLrR4dXWkcxO1cWYZEOX8DKHTqA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@ungap/structured-clone@1.3.3':
+    resolution: {integrity: sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==}
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
     resolution: {integrity: sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==}
@@ -2540,6 +2613,10 @@ packages:
   ast-v8-to-istanbul@1.0.3:
     resolution: {integrity: sha512-jCMQ6ZylLPudp0CDfBmQBZUsrh1/8psbmu9ibeVWKuHWD0YrH9YABwlKu5kVEFoT0GCQQW9Z/SxfuEbbkGQCRg==}
 
+  astring@1.9.0:
+    resolution: {integrity: sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==}
+    hasBin: true
+
   async-function@1.0.0:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
     engines: {node: '>= 0.4'}
@@ -2555,6 +2632,9 @@ packages:
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
+
+  bail@2.0.2:
+    resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
 
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
@@ -2600,6 +2680,9 @@ packages:
   caniuse-lite@1.0.30001788:
     resolution: {integrity: sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==}
 
+  ccount@2.0.1:
+    resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
@@ -2607,6 +2690,18 @@ packages:
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
+
+  character-entities-html4@2.1.0:
+    resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
+
+  character-entities-legacy@3.0.0:
+    resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
+
+  character-entities@2.0.2:
+    resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
+
+  character-reference-invalid@2.0.1:
+    resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
 
   chrome-trace-event@1.0.4:
     resolution: {integrity: sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==}
@@ -2643,6 +2738,9 @@ packages:
       react: ^18 || ^19 || ^19.0.0-rc
       react-dom: ^18 || ^19 || ^19.0.0-rc
 
+  collapse-white-space@2.1.0:
+    resolution: {integrity: sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==}
+
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
@@ -2652,6 +2750,9 @@ packages:
 
   colorette@2.0.20:
     resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
+
+  comma-separated-tokens@2.0.3:
+    resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
   commander@14.0.3:
     resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
@@ -2791,6 +2892,9 @@ packages:
   decimal.js-light@2.5.1:
     resolution: {integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==}
 
+  decode-named-character-reference@1.3.0:
+    resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
+
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
@@ -2812,6 +2916,9 @@ packages:
 
   detect-node-es@1.1.0:
     resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
+
+  devlop@1.1.0:
+    resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
@@ -2907,6 +3014,12 @@ packages:
 
   es-toolkit@1.49.0:
     resolution: {integrity: sha512-G5iZ6Pc/FNRY/soKZHC+TxGDD83rHUDXxzaWhGCX44vAv/tMs56WMusnm/KMNK+luUPsgA9U28cGr4RDlSzL2g==}
+
+  esast-util-from-estree@2.0.0:
+    resolution: {integrity: sha512-4CyanoAudUSBAn5K13H4JhsMH6L9ZP7XbLVe/dKybkxMO7eDyLsT8UHl9TRNrU2Gr9nz+FovfSIjuXWJ81uVwQ==}
+
+  esast-util-from-js@2.0.1:
+    resolution: {integrity: sha512-8Ja+rNJ0Lt56Pcf3TAmpBZjmx8ZcK5Ts4cAzIOjsjevg9oSXJnl6SUQ2EevU8tv3h6ZLWmoKL5H4fgWvdvfETw==}
 
   esbuild@0.28.1:
     resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
@@ -3045,6 +3158,24 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-util-attach-comments@3.0.0:
+    resolution: {integrity: sha512-cKUwm/HUcTDsYh/9FgnuFqpfquUbwIqwKM26BVCGDPVgvaCl/nDCCjUfiLlx6lsEZ3Z4RFxNbOQ60pkaEwFxGw==}
+
+  estree-util-build-jsx@3.0.1:
+    resolution: {integrity: sha512-8U5eiL6BTrPxp/CHbs2yMgP8ftMhR5ww1eIKoWRMlqvltHF8fZn5LRDvTKuxD3DUn+shRbLGqXemcP51oFCsGQ==}
+
+  estree-util-is-identifier-name@3.0.0:
+    resolution: {integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==}
+
+  estree-util-scope@1.0.0:
+    resolution: {integrity: sha512-2CAASclonf+JFWBNJPndcOpA8EMJwa0Q8LUFJEKqXLW6+qBvbFZuF5gItbQOs/umBUkjviCSDCbBwU2cXbmrhQ==}
+
+  estree-util-to-js@2.0.0:
+    resolution: {integrity: sha512-WDF+xj5rRWmD5tj6bIqRi6CkLIXbbNQUcxQHzGysQzvHmdYG2G7p/Tf0J0gpxGgkeMZNTIjT/AoSvC9Xehcgdg==}
+
+  estree-util-visit@2.0.0:
+    resolution: {integrity: sha512-m5KgiH85xAhhW8Wta0vShLcUvOsh3LLPI2YVwcbio1l7E09NTLL1EyMZFM1OyWowoH0skScNbhOPl4kcBgzTww==}
+
   estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
@@ -3065,6 +3196,9 @@ packages:
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
+
+  extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -3264,6 +3398,15 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
+  hast-util-to-estree@3.1.3:
+    resolution: {integrity: sha512-48+B/rJWAp0jamNbAAf9M7Uf//UVqAoMmgXhBdxTDJLGKY+LRnZ99qcG+Qjl5HfMpYNzS5v4EAwVEF34LeAj7w==}
+
+  hast-util-to-jsx-runtime@2.3.6:
+    resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
+
+  hast-util-whitespace@3.0.0:
+    resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
@@ -3310,6 +3453,9 @@ packages:
     resolution: {integrity: sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
+  inline-style-parser@0.2.7:
+    resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
+
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
@@ -3317,6 +3463,12 @@ packages:
   internmap@2.0.3:
     resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
     engines: {node: '>=12'}
+
+  is-alphabetical@2.0.1:
+    resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
+
+  is-alphanumerical@2.0.1:
+    resolution: {integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==}
 
   is-array-buffer@3.0.5:
     resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
@@ -3356,6 +3508,9 @@ packages:
     resolution: {integrity: sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==}
     engines: {node: '>= 0.4'}
 
+  is-decimal@2.0.1:
+    resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
+
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
@@ -3379,6 +3534,9 @@ packages:
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
+
+  is-hexadecimal@2.0.1:
+    resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
 
   is-map@2.0.3:
     resolution: {integrity: sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==}
@@ -3649,6 +3807,9 @@ packages:
     resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
     engines: {node: '>=18'}
 
+  longest-streak@3.1.0:
+    resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
+
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
@@ -3679,9 +3840,40 @@ packages:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
 
+  markdown-extensions@2.0.0:
+    resolution: {integrity: sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q==}
+    engines: {node: '>=16'}
+
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
+
+  mdast-util-from-markdown@2.0.3:
+    resolution: {integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==}
+
+  mdast-util-mdx-expression@2.0.1:
+    resolution: {integrity: sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==}
+
+  mdast-util-mdx-jsx@3.2.0:
+    resolution: {integrity: sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==}
+
+  mdast-util-mdx@3.0.0:
+    resolution: {integrity: sha512-JfbYLAW7XnYTTbUsmpu0kdBUVe+yKVJZBItEjwyYJiDJuZ9w4eeaqks4HQO+R7objWgS2ymV60GYpI14Ug554w==}
+
+  mdast-util-mdxjs-esm@2.0.1:
+    resolution: {integrity: sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==}
+
+  mdast-util-phrasing@4.1.0:
+    resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
+
+  mdast-util-to-hast@13.2.1:
+    resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
+
+  mdast-util-to-markdown@2.1.2:
+    resolution: {integrity: sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==}
+
+  mdast-util-to-string@4.0.0:
+    resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
 
   meow@13.2.0:
     resolution: {integrity: sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==}
@@ -3693,6 +3885,90 @@ packages:
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
+
+  micromark-core-commonmark@2.0.3:
+    resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
+
+  micromark-extension-mdx-expression@3.0.1:
+    resolution: {integrity: sha512-dD/ADLJ1AeMvSAKBwO22zG22N4ybhe7kFIZ3LsDI0GlsNr2A3KYxb0LdC1u5rj4Nw+CHKY0RVdnHX8vj8ejm4Q==}
+
+  micromark-extension-mdx-jsx@3.0.2:
+    resolution: {integrity: sha512-e5+q1DjMh62LZAJOnDraSSbDMvGJ8x3cbjygy2qFEi7HCeUT4BDKCvMozPozcD6WmOt6sVvYDNBKhFSz3kjOVQ==}
+
+  micromark-extension-mdx-md@2.0.0:
+    resolution: {integrity: sha512-EpAiszsB3blw4Rpba7xTOUptcFeBFi+6PY8VnJ2hhimH+vCQDirWgsMpz7w1XcZE7LVrSAUGb9VJpG9ghlYvYQ==}
+
+  micromark-extension-mdxjs-esm@3.0.0:
+    resolution: {integrity: sha512-DJFl4ZqkErRpq/dAPyeWp15tGrcrrJho1hKK5uBS70BCtfrIFg81sqcTVu3Ta+KD1Tk5vAtBNElWxtAa+m8K9A==}
+
+  micromark-extension-mdxjs@3.0.0:
+    resolution: {integrity: sha512-A873fJfhnJ2siZyUrJ31l34Uqwy4xIFmvPY1oj+Ean5PHcPBYzEsvqvWGaWcfEIr11O5Dlw3p2y0tZWpKHDejQ==}
+
+  micromark-factory-destination@2.0.1:
+    resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
+
+  micromark-factory-label@2.0.1:
+    resolution: {integrity: sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==}
+
+  micromark-factory-mdx-expression@2.0.3:
+    resolution: {integrity: sha512-kQnEtA3vzucU2BkrIa8/VaSAsP+EJ3CKOvhMuJgOEGg9KDC6OAY6nSnNDVRiVNRqj7Y4SlSzcStaH/5jge8JdQ==}
+
+  micromark-factory-space@2.0.1:
+    resolution: {integrity: sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==}
+
+  micromark-factory-title@2.0.1:
+    resolution: {integrity: sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==}
+
+  micromark-factory-whitespace@2.0.1:
+    resolution: {integrity: sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==}
+
+  micromark-util-character@2.1.1:
+    resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
+
+  micromark-util-chunked@2.0.1:
+    resolution: {integrity: sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==}
+
+  micromark-util-classify-character@2.0.1:
+    resolution: {integrity: sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==}
+
+  micromark-util-combine-extensions@2.0.1:
+    resolution: {integrity: sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==}
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    resolution: {integrity: sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==}
+
+  micromark-util-decode-string@2.0.1:
+    resolution: {integrity: sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==}
+
+  micromark-util-encode@2.0.1:
+    resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
+
+  micromark-util-events-to-acorn@2.0.3:
+    resolution: {integrity: sha512-jmsiEIiZ1n7X1Rr5k8wVExBQCg5jy4UXVADItHmNk1zkwEVhBuIUKRu3fqv+hs4nxLISi2DQGlqIOGiFxgbfHg==}
+
+  micromark-util-html-tag-name@2.0.1:
+    resolution: {integrity: sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==}
+
+  micromark-util-normalize-identifier@2.0.1:
+    resolution: {integrity: sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==}
+
+  micromark-util-resolve-all@2.0.1:
+    resolution: {integrity: sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==}
+
+  micromark-util-sanitize-uri@2.0.1:
+    resolution: {integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==}
+
+  micromark-util-subtokenize@2.1.0:
+    resolution: {integrity: sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==}
+
+  micromark-util-symbol@2.0.1:
+    resolution: {integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==}
+
+  micromark-util-types@2.0.2:
+    resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
+
+  micromark@4.0.2:
+    resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
 
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
@@ -3868,6 +4144,9 @@ packages:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
 
+  parse-entities@4.0.2:
+    resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
+
   parse-json@5.2.0:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
@@ -3938,6 +4217,9 @@ packages:
 
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
+
+  property-information@7.2.0:
+    resolution: {integrity: sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==}
 
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
@@ -4028,6 +4310,20 @@ packages:
       react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-is: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  recma-build-jsx@1.0.0:
+    resolution: {integrity: sha512-8GtdyqaBcDfva+GUKDr3nev3VpKAhup1+RvkMvUxURHpW7QyIvk9F5wz7Vzo06CEMSilw6uArgRqhpiUcWp8ew==}
+
+  recma-jsx@1.0.1:
+    resolution: {integrity: sha512-huSIy7VU2Z5OLv6oFLosQGGDqPqdO1iq6bWNAdhzMxSJP7RAso4fCZ1cKu8j9YHCZf3TPrq4dw3okhrylgcd7w==}
+    peerDependencies:
+      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+
+  recma-parse@1.0.0:
+    resolution: {integrity: sha512-OYLsIGBB5Y5wjnSnQW6t3Xg7q3fQ7FWbw/vcXtORTnyaSFscOtABg+7Pnz6YZ6c27fG1/aN8CjfwoUEUIdwqWQ==}
+
+  recma-stringify@1.0.0:
+    resolution: {integrity: sha512-cjwII1MdIIVloKvC9ErQ+OgAtwHBmcZ0Bg4ciz78FtbT8In39aAYbaA7zvxQ61xVMSPE8WxhLwLbhif4Js2C+g==}
+
   redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
@@ -4047,6 +4343,18 @@ packages:
   regexp.prototype.flags@1.5.4:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
     engines: {node: '>= 0.4'}
+
+  rehype-recma@1.0.0:
+    resolution: {integrity: sha512-lqA4rGUf1JmacCNWWZx0Wv1dHqMwxzsDWYMTowuplHF3xH0N/MmrZ/G3BDZnzAkRmxDadujCjaKM2hqYdCBOGw==}
+
+  remark-mdx@3.1.1:
+    resolution: {integrity: sha512-Pjj2IYlUY3+D8x00UJsIOg5BEvfMyeI+2uLPn9VO9Wg4MEtN/VTIq2NEJQfde9PnX15KgtHyl9S0BcTnWrIuWg==}
+
+  remark-parse@11.0.0:
+    resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
+
+  remark-rehype@11.1.2:
+    resolution: {integrity: sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==}
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
@@ -4208,6 +4516,13 @@ packages:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
 
+  source-map@0.7.6:
+    resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
+    engines: {node: '>= 12'}
+
+  space-separated-tokens@2.0.2:
+    resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
 
@@ -4264,6 +4579,9 @@ packages:
     resolution: {integrity: sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==}
     engines: {node: '>= 0.4'}
 
+  stringify-entities@4.0.4:
+    resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
+
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
@@ -4283,6 +4601,12 @@ packages:
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
+
+  style-to-js@1.1.21:
+    resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
+
+  style-to-object@1.0.14:
+    resolution: {integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==}
 
   styled-jsx@5.1.6:
     resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
@@ -4404,6 +4728,12 @@ packages:
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
 
+  trim-lines@3.0.1:
+    resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
+
+  trough@2.2.0:
+    resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
+
   ts-api-utils@2.5.0:
     resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
     engines: {node: '>=18.12'}
@@ -4462,6 +4792,27 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
+  unified@11.0.5:
+    resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
+
+  unist-util-is@6.0.1:
+    resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
+
+  unist-util-position-from-estree@2.0.0:
+    resolution: {integrity: sha512-KaFVRjoqLyF6YXCbVLNad/eS4+OfPQQn2yOd7zF/h5T/CSL2v8NpN6a5TPvtbXthAGw5nG+PuTtq+DdIZr+cRQ==}
+
+  unist-util-position@5.0.0:
+    resolution: {integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==}
+
+  unist-util-stringify-position@4.0.0:
+    resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
+
+  unist-util-visit-parents@6.0.2:
+    resolution: {integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==}
+
+  unist-util-visit@5.1.0:
+    resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
+
   unrs-resolver@1.11.1:
     resolution: {integrity: sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==}
 
@@ -4498,6 +4849,12 @@ packages:
     resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  vfile-message@4.0.3:
+    resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
+
+  vfile@6.0.3:
+    resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
   victory-vendor@37.3.6:
     resolution: {integrity: sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==}
@@ -4692,6 +5049,12 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
+  zwitch@2.0.4:
+    resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
 
@@ -5310,6 +5673,51 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@mdx-js/loader@3.1.1(webpack@5.107.2(lightningcss@1.32.0))':
+    dependencies:
+      '@mdx-js/mdx': 3.1.1
+      source-map: 0.7.6
+    optionalDependencies:
+      webpack: 5.107.2(lightningcss@1.32.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@mdx-js/mdx@3.1.1':
+    dependencies:
+      '@types/estree': 1.0.9
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.5
+      '@types/mdx': 2.0.14
+      acorn: 8.16.0
+      collapse-white-space: 2.1.0
+      devlop: 1.1.0
+      estree-util-is-identifier-name: 3.0.0
+      estree-util-scope: 1.0.0
+      estree-walker: 3.0.3
+      hast-util-to-jsx-runtime: 2.3.6
+      markdown-extensions: 2.0.0
+      recma-build-jsx: 1.0.0
+      recma-jsx: 1.0.1(acorn@8.16.0)
+      recma-stringify: 1.0.0
+      rehype-recma: 1.0.0
+      remark-mdx: 3.1.1
+      remark-parse: 11.0.0
+      remark-rehype: 11.1.2
+      source-map: 0.7.6
+      unified: 11.0.5
+      unist-util-position-from-estree: 2.0.0
+      unist-util-stringify-position: 4.0.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.1.0)':
+    dependencies:
+      '@types/mdx': 2.0.14
+      '@types/react': 19.2.14
+      react: 19.1.0
+
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
       '@emnapi/core': 1.9.2
@@ -5322,6 +5730,13 @@ snapshots:
   '@next/eslint-plugin-next@15.5.2':
     dependencies:
       fast-glob: 3.3.1
+
+  '@next/mdx@16.2.12(@mdx-js/loader@3.1.1(webpack@5.107.2(lightningcss@1.32.0)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.1.0))':
+    dependencies:
+      source-map: 0.7.6
+    optionalDependencies:
+      '@mdx-js/loader': 3.1.1(webpack@5.107.2(lightningcss@1.32.0))
+      '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.1.0)
 
   '@next/swc-darwin-arm64@16.2.11':
     optional: true
@@ -6541,15 +6956,35 @@ snapshots:
 
   '@types/d3-timer@3.0.2': {}
 
+  '@types/debug@4.1.13':
+    dependencies:
+      '@types/ms': 2.1.0
+
   '@types/deep-eql@4.0.2': {}
+
+  '@types/estree-jsx@1.0.5':
+    dependencies:
+      '@types/estree': 1.0.9
 
   '@types/estree@1.0.8': {}
 
   '@types/estree@1.0.9': {}
 
+  '@types/hast@3.0.5':
+    dependencies:
+      '@types/unist': 3.0.3
+
   '@types/json-schema@7.0.15': {}
 
   '@types/json5@0.0.29': {}
+
+  '@types/mdast@4.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
+  '@types/mdx@2.0.14': {}
+
+  '@types/ms@2.1.0': {}
 
   '@types/node@20.19.39':
     dependencies:
@@ -6562,6 +6997,10 @@ snapshots:
   '@types/react@19.2.14':
     dependencies:
       csstype: 3.2.3
+
+  '@types/unist@2.0.11': {}
+
+  '@types/unist@3.0.3': {}
 
   '@types/use-sync-external-store@0.0.6': {}
 
@@ -6661,6 +7100,8 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.58.2
       eslint-visitor-keys: 5.0.1
+
+  '@ungap/structured-clone@1.3.3': {}
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
     optional: true
@@ -7028,6 +7469,8 @@ snapshots:
       estree-walker: 3.0.3
       js-tokens: 10.0.0
 
+  astring@1.9.0: {}
+
   async-function@1.0.0: {}
 
   available-typed-arrays@1.0.7:
@@ -7037,6 +7480,8 @@ snapshots:
   axe-core@4.11.3: {}
 
   axobject-query@4.1.0: {}
+
+  bail@2.0.2: {}
 
   balanced-match@4.0.4: {}
 
@@ -7081,12 +7526,22 @@ snapshots:
 
   caniuse-lite@1.0.30001788: {}
 
+  ccount@2.0.1: {}
+
   chai@6.2.2: {}
 
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
+
+  character-entities-html4@2.1.0: {}
+
+  character-entities-legacy@3.0.0: {}
+
+  character-entities@2.0.2: {}
+
+  character-reference-invalid@2.0.1: {}
 
   chrome-trace-event@1.0.4: {}
 
@@ -7127,6 +7582,8 @@ snapshots:
       - '@types/react'
       - '@types/react-dom'
 
+  collapse-white-space@2.1.0: {}
+
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
@@ -7134,6 +7591,8 @@ snapshots:
   color-name@1.1.4: {}
 
   colorette@2.0.20: {}
+
+  comma-separated-tokens@2.0.3: {}
 
   commander@14.0.3: {}
 
@@ -7257,6 +7716,10 @@ snapshots:
 
   decimal.js-light@2.5.1: {}
 
+  decode-named-character-reference@1.3.0:
+    dependencies:
+      character-entities: 2.0.2
+
   deep-is@0.1.4: {}
 
   define-data-property@1.1.4:
@@ -7276,6 +7739,10 @@ snapshots:
   detect-libc@2.1.2: {}
 
   detect-node-es@1.1.0: {}
+
+  devlop@1.1.0:
+    dependencies:
+      dequal: 2.0.3
 
   doctrine@2.1.0:
     dependencies:
@@ -7429,6 +7896,20 @@ snapshots:
       is-symbol: 1.1.1
 
   es-toolkit@1.49.0: {}
+
+  esast-util-from-estree@2.0.0:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      devlop: 1.1.0
+      estree-util-visit: 2.0.0
+      unist-util-position-from-estree: 2.0.0
+
+  esast-util-from-js@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      acorn: 8.16.0
+      esast-util-from-estree: 2.0.0
+      vfile-message: 4.0.3
 
   esbuild@0.28.1:
     optionalDependencies:
@@ -7666,11 +8147,40 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-util-attach-comments@3.0.0:
+    dependencies:
+      '@types/estree': 1.0.9
+
+  estree-util-build-jsx@3.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      devlop: 1.1.0
+      estree-util-is-identifier-name: 3.0.0
+      estree-walker: 3.0.3
+
+  estree-util-is-identifier-name@3.0.0: {}
+
+  estree-util-scope@1.0.0:
+    dependencies:
+      '@types/estree': 1.0.9
+      devlop: 1.1.0
+
+  estree-util-to-js@2.0.0:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      astring: 1.9.0
+      source-map: 0.7.6
+
+  estree-util-visit@2.0.0:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/unist': 3.0.3
+
   estree-walker@2.0.2: {}
 
   estree-walker@3.0.3:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
 
   esutils@2.0.3: {}
 
@@ -7679,6 +8189,8 @@ snapshots:
   events@3.3.0: {}
 
   expect-type@1.3.0: {}
+
+  extend@3.0.2: {}
 
   fast-deep-equal@3.1.3: {}
 
@@ -7873,6 +8385,51 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hast-util-to-estree@3.1.3:
+    dependencies:
+      '@types/estree': 1.0.9
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.5
+      comma-separated-tokens: 2.0.3
+      devlop: 1.1.0
+      estree-util-attach-comments: 3.0.0
+      estree-util-is-identifier-name: 3.0.0
+      hast-util-whitespace: 3.0.0
+      mdast-util-mdx-expression: 2.0.1
+      mdast-util-mdx-jsx: 3.2.0
+      mdast-util-mdxjs-esm: 2.0.1
+      property-information: 7.2.0
+      space-separated-tokens: 2.0.2
+      style-to-js: 1.1.21
+      unist-util-position: 5.0.0
+      zwitch: 2.0.4
+    transitivePeerDependencies:
+      - supports-color
+
+  hast-util-to-jsx-runtime@2.3.6:
+    dependencies:
+      '@types/estree': 1.0.9
+      '@types/hast': 3.0.5
+      '@types/unist': 3.0.3
+      comma-separated-tokens: 2.0.3
+      devlop: 1.1.0
+      estree-util-is-identifier-name: 3.0.0
+      hast-util-whitespace: 3.0.0
+      mdast-util-mdx-expression: 2.0.1
+      mdast-util-mdx-jsx: 3.2.0
+      mdast-util-mdxjs-esm: 2.0.1
+      property-information: 7.2.0
+      space-separated-tokens: 2.0.2
+      style-to-js: 1.1.21
+      unist-util-position: 5.0.0
+      vfile-message: 4.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  hast-util-whitespace@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.5
+
   html-escaper@2.0.2: {}
 
   https-proxy-agent@5.0.1:
@@ -7910,6 +8467,8 @@ snapshots:
 
   ini@4.1.1: {}
 
+  inline-style-parser@0.2.7: {}
+
   internal-slot@1.1.0:
     dependencies:
       es-errors: 1.3.0
@@ -7917,6 +8476,13 @@ snapshots:
       side-channel: 1.1.0
 
   internmap@2.0.3: {}
+
+  is-alphabetical@2.0.1: {}
+
+  is-alphanumerical@2.0.1:
+    dependencies:
+      is-alphabetical: 2.0.1
+      is-decimal: 2.0.1
 
   is-array-buffer@3.0.5:
     dependencies:
@@ -7964,6 +8530,8 @@ snapshots:
       call-bound: 1.0.4
       has-tostringtag: 1.0.2
 
+  is-decimal@2.0.1: {}
+
   is-extglob@2.1.1: {}
 
   is-finalizationregistry@1.1.1:
@@ -7987,6 +8555,8 @@ snapshots:
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
+
+  is-hexadecimal@2.0.1: {}
 
   is-map@2.0.3: {}
 
@@ -8225,6 +8795,8 @@ snapshots:
       strip-ansi: 7.2.0
       wrap-ansi: 9.0.2
 
+  longest-streak@3.1.0: {}
+
   loose-envify@1.4.0:
     dependencies:
       js-tokens: 4.0.0
@@ -8255,13 +8827,320 @@ snapshots:
     dependencies:
       semver: 7.7.4
 
+  markdown-extensions@2.0.0: {}
+
   math-intrinsics@1.1.0: {}
+
+  mdast-util-from-markdown@2.0.3:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      mdast-util-to-string: 4.0.0
+      micromark: 4.0.2
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-decode-string: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      unist-util-stringify-position: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-expression@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.5
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-jsx@3.2.0:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.5
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      parse-entities: 4.0.2
+      stringify-entities: 4.0.4
+      unist-util-stringify-position: 4.0.0
+      vfile-message: 4.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx@3.0.0:
+    dependencies:
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-mdx-expression: 2.0.1
+      mdast-util-mdx-jsx: 3.2.0
+      mdast-util-mdxjs-esm: 2.0.1
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdxjs-esm@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.5
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-phrasing@4.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      unist-util-is: 6.0.1
+
+  mdast-util-to-hast@13.2.1:
+    dependencies:
+      '@types/hast': 3.0.5
+      '@types/mdast': 4.0.4
+      '@ungap/structured-clone': 1.3.3
+      devlop: 1.1.0
+      micromark-util-sanitize-uri: 2.0.1
+      trim-lines: 3.0.1
+      unist-util-position: 5.0.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+
+  mdast-util-to-markdown@2.1.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      longest-streak: 3.1.0
+      mdast-util-phrasing: 4.1.0
+      mdast-util-to-string: 4.0.0
+      micromark-util-classify-character: 2.0.1
+      micromark-util-decode-string: 2.0.1
+      unist-util-visit: 5.1.0
+      zwitch: 2.0.4
+
+  mdast-util-to-string@4.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
 
   meow@13.2.0: {}
 
   merge-stream@2.0.0: {}
 
   merge2@1.4.1: {}
+
+  micromark-core-commonmark@2.0.3:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-factory-destination: 2.0.1
+      micromark-factory-label: 2.0.1
+      micromark-factory-space: 2.0.1
+      micromark-factory-title: 2.0.1
+      micromark-factory-whitespace: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-html-tag-name: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-mdx-expression@3.0.1:
+    dependencies:
+      '@types/estree': 1.0.9
+      devlop: 1.1.0
+      micromark-factory-mdx-expression: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-events-to-acorn: 2.0.3
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-mdx-jsx@3.0.2:
+    dependencies:
+      '@types/estree': 1.0.9
+      devlop: 1.1.0
+      estree-util-is-identifier-name: 3.0.0
+      micromark-factory-mdx-expression: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-events-to-acorn: 2.0.3
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      vfile-message: 4.0.3
+
+  micromark-extension-mdx-md@2.0.0:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-extension-mdxjs-esm@3.0.0:
+    dependencies:
+      '@types/estree': 1.0.9
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-util-character: 2.1.1
+      micromark-util-events-to-acorn: 2.0.3
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      unist-util-position-from-estree: 2.0.0
+      vfile-message: 4.0.3
+
+  micromark-extension-mdxjs@3.0.0:
+    dependencies:
+      acorn: 8.16.0
+      acorn-jsx: 5.3.2(acorn@8.16.0)
+      micromark-extension-mdx-expression: 3.0.1
+      micromark-extension-mdx-jsx: 3.0.2
+      micromark-extension-mdx-md: 2.0.0
+      micromark-extension-mdxjs-esm: 3.0.0
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-destination@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-label@2.0.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-mdx-expression@2.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-events-to-acorn: 2.0.3
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      unist-util-position-from-estree: 2.0.0
+      vfile-message: 4.0.3
+
+  micromark-factory-space@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-title@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-whitespace@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-character@2.1.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-chunked@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-classify-character@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-combine-extensions@2.0.1:
+    dependencies:
+      micromark-util-chunked: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-decode-string@2.0.1:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      micromark-util-character: 2.1.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-encode@2.0.1: {}
+
+  micromark-util-events-to-acorn@2.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+      '@types/unist': 3.0.3
+      devlop: 1.1.0
+      estree-util-visit: 2.0.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      vfile-message: 4.0.3
+
+  micromark-util-html-tag-name@2.0.1: {}
+
+  micromark-util-normalize-identifier@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-resolve-all@2.0.1:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-util-sanitize-uri@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-encode: 2.0.1
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-subtokenize@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-symbol@2.0.1: {}
+
+  micromark-util-types@2.0.2: {}
+
+  micromark@4.0.2:
+    dependencies:
+      '@types/debug': 4.1.13
+      debug: 4.4.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-encode: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   micromatch@4.0.8:
     dependencies:
@@ -8432,6 +9311,16 @@ snapshots:
     dependencies:
       callsites: 3.1.0
 
+  parse-entities@4.0.2:
+    dependencies:
+      '@types/unist': 2.0.11
+      character-entities-legacy: 3.0.0
+      character-reference-invalid: 2.0.1
+      decode-named-character-reference: 1.3.0
+      is-alphanumerical: 2.0.1
+      is-decimal: 2.0.1
+      is-hexadecimal: 2.0.1
+
   parse-json@5.2.0:
     dependencies:
       '@babel/code-frame': 7.29.0
@@ -8491,6 +9380,8 @@ snapshots:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       react-is: 16.13.1
+
+  property-information@7.2.0: {}
 
   proxy-from-env@1.1.0: {}
 
@@ -8575,6 +9466,35 @@ snapshots:
       - '@types/react'
       - redux
 
+  recma-build-jsx@1.0.0:
+    dependencies:
+      '@types/estree': 1.0.9
+      estree-util-build-jsx: 3.0.1
+      vfile: 6.0.3
+
+  recma-jsx@1.0.1(acorn@8.16.0):
+    dependencies:
+      acorn: 8.16.0
+      acorn-jsx: 5.3.2(acorn@8.16.0)
+      estree-util-to-js: 2.0.0
+      recma-parse: 1.0.0
+      recma-stringify: 1.0.0
+      unified: 11.0.5
+
+  recma-parse@1.0.0:
+    dependencies:
+      '@types/estree': 1.0.9
+      esast-util-from-js: 2.0.1
+      unified: 11.0.5
+      vfile: 6.0.3
+
+  recma-stringify@1.0.0:
+    dependencies:
+      '@types/estree': 1.0.9
+      estree-util-to-js: 2.0.0
+      unified: 11.0.5
+      vfile: 6.0.3
+
   redent@3.0.0:
     dependencies:
       indent-string: 4.0.0
@@ -8605,6 +9525,38 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       set-function-name: 2.0.2
+
+  rehype-recma@1.0.0:
+    dependencies:
+      '@types/estree': 1.0.9
+      '@types/hast': 3.0.5
+      hast-util-to-estree: 3.1.3
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-mdx@3.1.1:
+    dependencies:
+      mdast-util-mdx: 3.0.0
+      micromark-extension-mdxjs: 3.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-parse@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      micromark-util-types: 2.0.2
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-rehype@11.1.2:
+    dependencies:
+      '@types/hast': 3.0.5
+      '@types/mdast': 4.0.4
+      mdast-util-to-hast: 13.2.1
+      unified: 11.0.5
+      vfile: 6.0.3
 
   require-directory@2.1.1: {}
 
@@ -8831,6 +9783,10 @@ snapshots:
 
   source-map@0.6.1: {}
 
+  source-map@0.7.6: {}
+
+  space-separated-tokens@2.0.2: {}
+
   stable-hash@0.0.5: {}
 
   stackback@0.0.2: {}
@@ -8915,6 +9871,11 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
 
+  stringify-entities@4.0.4:
+    dependencies:
+      character-entities-html4: 2.1.0
+      character-entities-legacy: 3.0.0
+
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
@@ -8930,6 +9891,14 @@ snapshots:
       min-indent: 1.0.1
 
   strip-json-comments@3.1.1: {}
+
+  style-to-js@1.1.21:
+    dependencies:
+      style-to-object: 1.0.14
+
+  style-to-object@1.0.14:
+    dependencies:
+      inline-style-parser: 0.2.7
 
   styled-jsx@5.1.6(@babel/core@7.29.7)(react@19.1.0):
     dependencies:
@@ -8998,6 +9967,10 @@ snapshots:
 
   tr46@0.0.3: {}
 
+  trim-lines@3.0.1: {}
+
+  trough@2.2.0: {}
+
   ts-api-utils@2.5.0(typescript@5.9.3):
     dependencies:
       typescript: 5.9.3
@@ -9065,6 +10038,43 @@ snapshots:
 
   undici-types@6.21.0: {}
 
+  unified@11.0.5:
+    dependencies:
+      '@types/unist': 3.0.3
+      bail: 2.0.2
+      devlop: 1.1.0
+      extend: 3.0.2
+      is-plain-obj: 4.1.0
+      trough: 2.2.0
+      vfile: 6.0.3
+
+  unist-util-is@6.0.1:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-position-from-estree@2.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-position@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-stringify-position@4.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-visit-parents@6.0.2:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+
+  unist-util-visit@5.1.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
   unrs-resolver@1.11.1:
     dependencies:
       napi-postinstall: 0.3.4
@@ -9117,6 +10127,16 @@ snapshots:
   use-sync-external-store@1.6.0(react@19.1.0):
     dependencies:
       react: 19.1.0
+
+  vfile-message@4.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-stringify-position: 4.0.0
+
+  vfile@6.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile-message: 4.0.3
 
   victory-vendor@37.3.6:
     dependencies:
@@ -9332,3 +10352,7 @@ snapshots:
       yargs-parser: 21.1.1
 
   yocto-queue@0.1.0: {}
+
+  zod@4.4.3: {}
+
+  zwitch@2.0.4: {}

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,0 +1,26 @@
+import type { Metadata } from 'next'
+import AboutContent from '@/content/about.mdx'
+import { Prose } from '@/components/writing/prose'
+
+export const metadata: Metadata = {
+  title: 'About',
+  description: 'Who Crawford Young is, and what he builds.',
+  alternates: { canonical: '/about' },
+  openGraph: {
+    title: 'About',
+    description: 'Who Crawford Young is, and what he builds.',
+    url: '/about',
+    siteName: 'Crawford Young',
+    type: 'profile',
+  },
+}
+
+export default function AboutPage(): React.JSX.Element {
+  return (
+    <div className="mx-auto max-w-2xl px-6 py-16">
+      <Prose>
+        <AboutContent />
+      </Prose>
+    </div>
+  )
+}

--- a/src/app/projects/[slug]/content-map.ts
+++ b/src/app/projects/[slug]/content-map.ts
@@ -1,0 +1,12 @@
+import type { ComponentType } from 'react'
+
+export const projectContent: Readonly<Record<string, () => Promise<{ default: ComponentType }>>> = {
+  'component-library': () => import('@/content/projects/component-library.mdx'),
+  'portfolio-website': () => import('@/content/projects/portfolio-website.mdx'),
+  cybond: () => import('@/content/projects/cybond.mdx'),
+  'web-dev-club': () => import('@/content/projects/web-dev-club.mdx'),
+  'ai-chess-bot': () => import('@/content/projects/ai-chess-bot.mdx'),
+  'instrument-tuner': () => import('@/content/projects/instrument-tuner.mdx'),
+  'ai-pacman': () => import('@/content/projects/ai-pacman.mdx'),
+  'html-idle-game': () => import('@/content/projects/html-idle-game.mdx'),
+}

--- a/src/app/projects/[slug]/page.tsx
+++ b/src/app/projects/[slug]/page.tsx
@@ -3,7 +3,9 @@ import Link from 'next/link'
 import { notFound } from 'next/navigation'
 import { Badge, Button } from '@/lib/ui'
 import { ArrowLeft, Github, ExternalLink, Package } from 'lucide-react'
+import { Prose } from '@/components/writing/prose'
 import { projects } from '@/data/projects'
+import { projectContent } from './content-map'
 
 type Params = { params: Promise<{ slug: string }> }
 
@@ -15,13 +17,28 @@ export async function generateMetadata({ params }: Params): Promise<Metadata> {
   const { slug } = await params
   const project = projects.find((p) => p.slug === slug)
   if (!project) return { title: 'Not found' }
-  return { title: project.title, description: project.description }
+  return {
+    title: project.title,
+    description: project.description,
+    alternates: { canonical: `/projects/${project.slug}` },
+    openGraph: {
+      title: project.title,
+      description: project.description,
+      url: `/projects/${project.slug}`,
+      siteName: 'Crawford Young',
+      type: 'article',
+    },
+  }
 }
 
 export default async function ProjectDetailPage({ params }: Params) {
   const { slug } = await params
   const project = projects.find((p) => p.slug === slug)
   if (!project) notFound()
+
+  const loader = projectContent[slug]
+  if (!loader) notFound()
+  const { default: Writeup } = await loader()
 
   return (
     <div className="mx-auto max-w-3xl px-6 py-16">
@@ -62,6 +79,11 @@ export default async function ProjectDetailPage({ params }: Params) {
             </a>
           </Button>
         )}
+      </div>
+      <div className="mt-12 border-t border-border pt-10">
+        <Prose>
+          <Writeup />
+        </Prose>
       </div>
     </div>
   )

--- a/src/app/writing/[slug]/page.tsx
+++ b/src/app/writing/[slug]/page.tsx
@@ -1,0 +1,54 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { notFound } from 'next/navigation'
+import { ArrowLeft } from 'lucide-react'
+import { collections, STORY, writingPath, writingSlugs } from '@/data/writing'
+import { Prose } from '@/components/writing/prose'
+import { writingContent } from '../content-map'
+
+type Params = { params: Promise<{ slug: string }> }
+
+export const dynamicParams = false
+
+export function generateStaticParams() {
+  return writingSlugs().map((slug) => ({ slug }))
+}
+
+export async function generateMetadata({ params }: Params): Promise<Metadata> {
+  const { slug } = await params
+  const collection = collections.find((c) => c.slug === slug)
+  const title = collection ? collection.title : STORY.title
+  const description = collection ? collection.description : STORY.description
+  return {
+    title,
+    description,
+    alternates: { canonical: writingPath(slug) },
+    openGraph: {
+      title,
+      description,
+      url: writingPath(slug),
+      siteName: 'Crawford Young',
+      type: 'article',
+    },
+  }
+}
+
+export default async function WritingPiecePage({ params }: Params) {
+  const { slug } = await params
+  const loader = writingContent[slug]
+  if (!loader) notFound()
+  const { default: Content } = await loader()
+  return (
+    <div className="mx-auto max-w-2xl px-6 py-16">
+      <Link
+        href="/writing"
+        className="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors mb-10"
+      >
+        <ArrowLeft className="h-4 w-4" /> Back to writing
+      </Link>
+      <Prose>
+        <Content />
+      </Prose>
+    </div>
+  )
+}

--- a/src/app/writing/content-map.ts
+++ b/src/app/writing/content-map.ts
@@ -1,0 +1,8 @@
+import type { ComponentType } from 'react'
+
+export const writingContent: Readonly<Record<string, () => Promise<{ default: ComponentType }>>> = {
+  'halfway-found': () => import('@/content/writing/halfway-found.mdx'),
+  almost: () => import('@/content/writing/almost.mdx'),
+  'you-cant-halfway-jump': () => import('@/content/writing/you-cant-halfway-jump.mdx'),
+  'the-hiker': () => import('@/content/writing/the-hiker.mdx'),
+}

--- a/src/app/writing/page.tsx
+++ b/src/app/writing/page.tsx
@@ -6,7 +6,7 @@ import { Spotlight } from '@/components/effects/spotlight'
 import { GlowCard } from '@/components/effects/glow-card'
 import { collections, STORY, writingPath } from '@/data/writing'
 
-const SUBSTACK_URL = 'https://crawfordyoung.substack.com/subscribe'
+const SUBSTACK_URL = 'https://crawfordyoung.substack.com/'
 const SINGLE_POEM_COUNT = 1
 
 export const metadata: Metadata = {
@@ -98,14 +98,15 @@ export default function WritingPage(): React.JSX.Element {
                   href={SUBSTACK_URL}
                   target="_blank"
                   rel="noreferrer"
-                  aria-label="Read on Substack"
+                  aria-label="Open Substack"
                   className="shrink-0"
                 >
                   <ExternalLink className="h-4 w-4 text-muted-foreground group-hover:text-accent transition-colors" />
                 </a>
               </div>
               <p className="text-sm text-muted-foreground leading-relaxed flex-1">
-                Subscribe on Substack for new poems and stories as they&apos;re written.
+                New poems and stories land on Substack as they&apos;re written — read everything
+                there.
               </p>
               <a
                 href={SUBSTACK_URL}
@@ -113,7 +114,7 @@ export default function WritingPage(): React.JSX.Element {
                 rel="noreferrer"
                 className="text-xs text-muted-foreground hover:text-foreground transition-colors"
               >
-                Subscribe on Substack
+                Read on Substack
               </a>
             </CardContent>
           </Card>

--- a/src/app/writing/page.tsx
+++ b/src/app/writing/page.tsx
@@ -1,0 +1,124 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { ArrowUpRight, ExternalLink } from 'lucide-react'
+import { Card, CardContent } from '@/lib/ui'
+import { Spotlight } from '@/components/effects/spotlight'
+import { GlowCard } from '@/components/effects/glow-card'
+import { collections, STORY, writingPath } from '@/data/writing'
+
+const SUBSTACK_URL = 'https://crawfordyoung.substack.com/subscribe'
+const SINGLE_POEM_COUNT = 1
+
+export const metadata: Metadata = {
+  title: 'Writing',
+  description: 'Poetry collections and a short story — plus where to read more on Substack.',
+  alternates: { canonical: '/writing' },
+  openGraph: {
+    title: 'Writing',
+    description: 'Poetry collections and a short story — plus where to read more on Substack.',
+    url: '/writing',
+    siteName: 'Crawford Young',
+    type: 'website',
+  },
+}
+
+function poemCountLabel(count: number): string {
+  return count === SINGLE_POEM_COUNT ? '1 poem' : `${count} poems`
+}
+
+export default function WritingPage(): React.JSX.Element {
+  return (
+    <div className="mx-auto max-w-5xl px-6 py-16">
+      <Spotlight className="rounded-2xl mb-12">
+        <div className="py-12 px-2">
+          <p className="text-xs font-semibold tracking-[0.2em] uppercase text-accent mb-3">Words</p>
+          <h1 className="text-4xl md:text-5xl font-bold tracking-[-0.03em]">Writing</h1>
+          <p className="mt-3 text-muted-foreground max-w-md">
+            Poetry collections and a short story, plus where to read more.
+          </p>
+        </div>
+      </Spotlight>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        {collections.map((collection) => (
+          <GlowCard key={collection.slug} className="h-full">
+            <Card className="h-full bg-surface/40 backdrop-blur-md border-border/60 hover:border-border transition-colors group">
+              <CardContent className="p-6 flex flex-col gap-4 h-full">
+                <div className="flex items-start justify-between">
+                  <h2 className="font-semibold text-foreground tracking-tight text-base leading-snug pr-4">
+                    {collection.title}
+                  </h2>
+                  <Link
+                    href={writingPath(collection.slug)}
+                    aria-label={`Read ${collection.title}`}
+                    className="shrink-0"
+                  >
+                    <ArrowUpRight className="h-4 w-4 text-muted-foreground group-hover:text-accent transition-colors" />
+                  </Link>
+                </div>
+                <p className="text-sm text-muted-foreground leading-relaxed flex-1">
+                  {collection.description}
+                </p>
+                <span className="text-xs text-muted-foreground">
+                  {poemCountLabel(collection.poems.length)}
+                </span>
+              </CardContent>
+            </Card>
+          </GlowCard>
+        ))}
+        <GlowCard className="h-full">
+          <Card className="h-full bg-surface/40 backdrop-blur-md border-border/60 hover:border-border transition-colors group">
+            <CardContent className="p-6 flex flex-col gap-4 h-full">
+              <div className="flex items-start justify-between">
+                <h2 className="font-semibold text-foreground tracking-tight text-base leading-snug pr-4">
+                  {STORY.title}
+                </h2>
+                <Link
+                  href={writingPath(STORY.slug)}
+                  aria-label={`Read ${STORY.title}`}
+                  className="shrink-0"
+                >
+                  <ArrowUpRight className="h-4 w-4 text-muted-foreground group-hover:text-accent transition-colors" />
+                </Link>
+              </div>
+              <p className="text-sm text-muted-foreground leading-relaxed flex-1">
+                {STORY.description}
+              </p>
+              <span className="text-xs text-muted-foreground">Short story</span>
+            </CardContent>
+          </Card>
+        </GlowCard>
+        <GlowCard className="h-full">
+          <Card className="h-full bg-surface/40 backdrop-blur-md border-border/60 hover:border-border transition-colors group">
+            <CardContent className="p-6 flex flex-col gap-4 h-full">
+              <div className="flex items-start justify-between">
+                <h2 className="font-semibold text-foreground tracking-tight text-base leading-snug pr-4">
+                  Read these on Substack
+                </h2>
+                <a
+                  href={SUBSTACK_URL}
+                  target="_blank"
+                  rel="noreferrer"
+                  aria-label="Read on Substack"
+                  className="shrink-0"
+                >
+                  <ExternalLink className="h-4 w-4 text-muted-foreground group-hover:text-accent transition-colors" />
+                </a>
+              </div>
+              <p className="text-sm text-muted-foreground leading-relaxed flex-1">
+                Subscribe on Substack for new poems and stories as they&apos;re written.
+              </p>
+              <a
+                href={SUBSTACK_URL}
+                target="_blank"
+                rel="noreferrer"
+                className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+              >
+                Subscribe on Substack
+              </a>
+            </CardContent>
+          </Card>
+        </GlowCard>
+      </div>
+    </div>
+  )
+}

--- a/src/components/effects/glow-card.tsx
+++ b/src/components/effects/glow-card.tsx
@@ -33,7 +33,7 @@ export function GlowCard({ children, className }: GlowCardProps) {
       ref={ref}
       onMouseMove={onMouseMove}
       onMouseLeave={onMouseLeave}
-      className={cn('relative group', className)}
+      className={cn('relative group rounded-xl', className)}
       style={{ '--gx': '50%', '--gy': '50%' } as React.CSSProperties}
     >
       {!reduced && (

--- a/src/components/layout/nav.tsx
+++ b/src/components/layout/nav.tsx
@@ -9,6 +9,7 @@ import { cn } from '@/lib/utils'
 const NAV_LINKS = [
   { href: '/', label: 'Home' },
   { href: '/projects', label: 'Projects' },
+  { href: '/writing', label: 'Writing' },
   { href: '/hobbies', label: 'Hobbies' },
   { href: '/experience', label: 'Experience' },
 ]

--- a/src/components/layout/nav.tsx
+++ b/src/components/layout/nav.tsx
@@ -12,6 +12,7 @@ const NAV_LINKS = [
   { href: '/writing', label: 'Writing' },
   { href: '/hobbies', label: 'Hobbies' },
   { href: '/experience', label: 'Experience' },
+  { href: '/about', label: 'About' },
 ]
 
 export function PillNav() {

--- a/src/components/writing/poem.tsx
+++ b/src/components/writing/poem.tsx
@@ -5,5 +5,9 @@ interface PoemProps {
 }
 
 export function Poem({ children }: PoemProps): ReactNode {
-  return <div className="whitespace-pre-line leading-8">{children}</div>
+  return (
+    <div className="whitespace-pre-line leading-8 rounded-xl border border-border/60 bg-surface/40 p-6 md:p-8 my-8 text-foreground">
+      {children}
+    </div>
+  )
 }

--- a/src/components/writing/poem.tsx
+++ b/src/components/writing/poem.tsx
@@ -1,0 +1,9 @@
+import type { ReactNode } from 'react'
+
+interface PoemProps {
+  readonly children: string
+}
+
+export function Poem({ children }: PoemProps): ReactNode {
+  return <div className="whitespace-pre-line leading-8">{children}</div>
+}

--- a/src/components/writing/prose.tsx
+++ b/src/components/writing/prose.tsx
@@ -1,0 +1,19 @@
+interface ProseProps {
+  readonly children: React.ReactNode
+}
+
+// Tailwind child selectors, not an mdx-components.tsx mapping — matches the
+// approach shipped in instrumenttuner's guide pages. Theme-token classes only
+// so both light and dark themes stay correct without a separate light pass.
+const ARTICLE_PROSE_CLASSES =
+  '[&_h1]:text-3xl [&_h1]:font-bold [&_h1]:tracking-tight [&_h1]:text-foreground ' +
+  '[&_h2]:mt-10 [&_h2]:text-xl [&_h2]:font-semibold [&_h2]:text-foreground ' +
+  '[&_p]:mt-4 [&_p]:leading-relaxed [&_p]:text-muted-foreground ' +
+  '[&_em]:text-foreground ' +
+  '[&_ul]:mt-3 [&_ul]:list-disc [&_ul]:space-y-2 [&_ul]:pl-5 [&_ul]:text-muted-foreground ' +
+  '[&_blockquote]:mt-4 [&_blockquote]:border-l-2 [&_blockquote]:border-border [&_blockquote]:pl-4 [&_blockquote]:text-muted-foreground ' +
+  '[&_a]:text-foreground [&_a]:underline [&_a]:underline-offset-4'
+
+export function Prose({ children }: ProseProps): React.JSX.Element {
+  return <article className={ARTICLE_PROSE_CLASSES}>{children}</article>
+}

--- a/src/content/about.mdx
+++ b/src/content/about.mdx
@@ -1,0 +1,13 @@
+# About
+
+I've been the tech guy in my family for as long as I can remember — when the wifi went out, everyone looked at me. That role turned into curiosity, curiosity turned into CS classes in high school, and I never looked back. I've always been a logical and creative person, and computer science is the middle of both: rigorous enough to satisfy the part of me that wants things to make sense, open-ended enough for the part that wants to make things.
+
+I studied computer science at Auburn University and graduated in fall 2025 — three and a half years, summa cum laude, as an Honors Scholar with a certificate in AI engineering. But the classroom was only half of it. I was president of the Web Development Club, running weekly build challenges for anyone who wanted to learn by making. I competed with the Competitive Programming team, poked at security with the Ethical Hacking Club, and stayed involved with ACM and the Honors College. Auburn is also where a lot of the [projects](/projects) on this site were born.
+
+Now I'm an Associate Software Engineer at Aderant in Atlanta, building AI-powered features for legal practice software — taking the machine learning I studied and putting it to work on problems real firms have every day.
+
+What drives me underneath all of it is self-improvement. I want to help people explore their interests in life and grow closer to the person they want to be — that's the thread connecting a scheduling app with a social accountability layer, a club built around weekly projects, and honestly, most of what I choose to work on.
+
+The rest of me lives outside the terminal. I spent nine summers at Camp Rockmont in the North Carolina mountains, first as a camper and then on staff as a whitewater kayaking and canoeing instructor. I play five instruments. I'll take a chess game whenever offered. And I write — poetry and short stories, which you can read over in [writing](/writing). I used to think those pieces of me were separate from the engineering; now I think they're the point. You have to be able to be yourself to fully bring yourself to the people around you — the philosophical side, the musical side, the fun side — and to help them do the same.
+
+If any of that sounds like something you want to talk about, [get in touch](/contact).

--- a/src/content/projects/ai-chess-bot.mdx
+++ b/src/content/projects/ai-chess-bot.mdx
@@ -1,0 +1,17 @@
+## The problem
+
+Chess puzzle sites hand everyone the same puzzles, roughly sorted by difficulty. But the mistakes I make aren't the mistakes you make — one player hangs pieces in the endgame, another collapses in sharp tactical middlegames. Generic puzzles train the average player, and nobody is the average player. For our COMP 6600 term project at Auburn — a group effort with Cooper Niebuhr and Kaden Range — we asked whether a system could read your actual game history and serve puzzles aimed at your specific weaknesses.
+
+## The approach
+
+The system is a Python pipeline that starts from raw game records in PGN format, the standard notation chess games are stored in. A parser walks each game move by move, an evaluation stage scores the positions to find the moments where a player's move made things measurably worse, and a categorizer labels what kind of mistake each one was. The key signal is the delta — the swing in evaluation before and after a move. A small delta is an inaccuracy; a large one is a blunder worth training against.
+
+From there, the mistakes become a profile: which categories of error show up most in your games. Puzzle selection targets those categories, so a player who keeps missing tactics gets tactical puzzles, and a player whose endgames leak points drills endgames. On the model side we trained a ResNet — a convolutional network architecture that has proven to work well on chess positions encoded as board planes — and the whole thing was written up as a proper paper in LaTeX, since the course treated the project as research, not just a build.
+
+## What I'd do differently
+
+Spend more of the budget on the data than the model. Like most student ML projects, the exciting part was the network, so that's where the time went — but the ceiling on the whole system was set by how well the categorizer labeled mistakes, and that stage got the least iteration. A sharper taxonomy of mistake types, validated against how coaches actually describe errors, would have improved the end product more than any architecture change.
+
+## What broke
+
+The pipeline's assumptions about real-world data. PGN files in the wild are messier than the spec suggests — annotations, variations, malformed headers, abandoned games. Early runs died mid-batch on files that looked fine at a glance, and the fix was the unglamorous kind: making the parser defensive, logging and skipping what it couldn't handle, and treating clean data as an output of the system rather than an input you get to assume.

--- a/src/content/projects/ai-pacman.mdx
+++ b/src/content/projects/ai-pacman.mdx
@@ -1,0 +1,21 @@
+## The problem
+
+How do you make one game teach an entire AI curriculum? That's the trick behind UC Berkeley's Pacman projects, which my AI coursework at Auburn was built on: Pacman looks like a toy, but underneath it's a clean testbed for the core problems of artificial intelligence — finding paths, playing against adversaries, learning from reward, and reasoning under uncertainty. The work was implementing the intelligence, in Python, across four escalating projects.
+
+## The approach
+
+The search project came first: depth-first, breadth-first, uniform-cost, and A* search, driving Pacman through mazes to reach goals efficiently. The interesting part isn't the algorithms — it's designing heuristics and problem representations, like the state you need to track for "eat every corner," where a naive encoding blows up and a careful one makes A* fly.
+
+The multiagent project made the ghosts matter: minimax with alpha-beta pruning, and expectimax for opponents that behave randomly rather than optimally. Writing the evaluation function is where the assignment gets real — the difference between an agent that wins and one that hides in a corner is entirely in how you score a position.
+
+Reinforcement learning came third: value iteration, then Q-learning, where the agent learns a policy purely from playing — no model of the world, just states, actions, and rewards. Watching a Q-learning agent go from random flailing to competent play without ever being told the rules is the moment the field clicks.
+
+The last project, tracking, was probabilistic inference: locating ghosts you can't see from noisy distance readings, using hidden Markov models and particle filters that maintain a belief distribution over where each ghost might be.
+
+## What I'd do differently
+
+Instrument earlier. My debugging default was print statements and squinting at the game board, and for the probabilistic projects that's nearly useless — a particle filter fails as a distribution drifting subtly wrong, not as a visible crash. Small visualizations of the belief state would have paid for themselves in the first hour.
+
+## What broke
+
+My expectimax agent, in an instructive way. Against the optimal-opponent assumption of minimax, my agent played fine; modeling random ghosts, it began taking risks that looked reckless — and scored better. Nothing was broken except my intuition: the "safe" play was only safe against a perfect adversary that didn't exist. Getting the opponent model right matters more than searching deeper, which is a lesson that generalizes well past Pacman.

--- a/src/content/projects/component-library.mdx
+++ b/src/content/projects/component-library.mdx
@@ -1,0 +1,17 @@
+## The problem
+
+Every project I started was rebuilding the same buttons, dialogs, and form fields — and every rebuild drifted a little. Different focus rings, different dark-mode handling, different accessibility gaps. I wanted one place where a component gets designed once, tested completely, and then consumed everywhere, so the design conversation happens a single time instead of once per repo.
+
+## The approach
+
+The library is built on Radix UI primitives with Tailwind and CVA for variants, published to npm as `@crawfordyoung/ui`. Radix handles the hard accessibility work — focus trapping, keyboard navigation, ARIA wiring — and I own everything visual on top of it. The design is dark-mode-first: every component is styled and reviewed in dark mode before light mode gets a pass, because dark is the default experience on my sites and designing light-first always left dark looking like an afterthought.
+
+Discipline is the actual product here. Every component ships with 100% test coverage, a Storybook story, and an axe accessibility pass before it merges. Storybook is the dev environment — I design in it, not in a consuming app. Releases go through Changesets so version bumps are deliberate, and the build outputs ESM, CJS, and type declarations so any consumer setup works.
+
+## What I'd do differently
+
+I'd design the extension model first. For a long stretch, whenever an app needed something extra on a component — a streak badge on a card, a lock icon on a calendar chip — I added a typed prop for it. Six waves of calendar work went into props encoding app concerns while a perfectly good render slot sat unused. The library now has a firm rule sorting every component into a class: primitives extend through `asChild` and className, composed shells expose named slots, and stateful interiors expose headless hooks with render-prop context. Apps own their domain; the library owns behavior. Getting there meant deleting shipped API, which is the expensive way to learn it.
+
+## What broke
+
+Time handling. Calendar components originally read hours off ISO strings directly, which silently reports UTC digits instead of the viewer's wall-clock time. Three separate features had independently grown the same bug — chip labels, time inputs, and overnight event splitting all showed the wrong hours for anyone not in UTC. The fix became a library-wide invariant: displayed times always come from local date getters on a parsed instant, never from slicing the string. One bug, three homes, one rule.

--- a/src/content/projects/cybond.mdx
+++ b/src/content/projects/cybond.mdx
@@ -1,0 +1,19 @@
+## The problem
+
+There's so much AI help for productivity now, and almost none of it solves the actual hard part: keeping yourself accountable. A model can plan your week in seconds — following through is the thing people quietly fail at, alone. That's why Cybond has a social layer on top of the tracking. Your schedule can be visible to people you choose, and being seen changes what you do.
+
+## The approach
+
+The core model took real iteration to get right. An activity is a metadata-only template — a title, session length bounds, a weekly target — with no schedule of its own. An event series holds a recurrence rule and materializes independent events on a rolling eight-week window; each generated event is an ordinary, fully editable calendar row with no sync back to the rule. Progress is a weekly fit score, completed sessions over target, derived on read.
+
+On top of that sits Cy, the AI assistant. It reads your activities and week, and proposes calendar changes as approval cards — a dashed preview of the event on that day's schedule, with a confirm and a deny. Nothing writes to your calendar without your click, and a deny sends your reason back so Cy revises. The social layer gives every user a public profile with a read-only week view, governed by per-event visibility: public shows details, busy shows only the time block, private never leaves the server.
+
+Google Calendar is opt-in through incremental OAuth — sign-in asks for identity only, and connecting your calendar is a separate consent for exactly two scopes. Stored tokens are encrypted at rest with AES-256-GCM.
+
+## What I'd do differently
+
+Start with the boring data model. The first version had one polymorphic table for everything — tasks, goals, habits — with recurrence groups and tombstone rows to keep deleted occurrences deleted. Every feature paid a tax to that flexibility. The rebuild went the opposite way: plain independent event rows, recurrence as a generator with a high-water mark instead of tombstones, and templates that carry no schedule at all. Fewer concepts, and each one does one thing.
+
+## What broke
+
+All-day events vanished. The event dialog stored them with a null start time, and the calendar filters rows without a start off the grid — so creating an all-day event made it unrecoverable through the UI, with every unit test green, because the tests mocked the calendar and never rendered the consequence. It only surfaced in hands-on QA. All-day events now persist real midnight-to-23:59 instants plus a flag, and the lesson stuck: for interactive UI, mocked tests prove you passed props, not that the feature works.

--- a/src/content/projects/html-idle-game.mdx
+++ b/src/content/projects/html-idle-game.mdx
@@ -1,0 +1,19 @@
+## The problem
+
+I love idle games — the genre where numbers go up while you're away and every upgrade makes the next one come faster. One day I wanted to know: how fast could I make one? Not a polished product, not a portfolio centerpiece — a speedrun. The question was whether the core loop that makes idle games compulsive could be stood up in a single sitting with nothing but a browser.
+
+## The approach
+
+The constraint was absolute minimalism: exactly three files — an HTML page, a script, and a stylesheet. No frameworks, no build step, no package manager, no server. Open the file in a browser and it runs. That's the entire deployment story.
+
+What makes the exercise interesting is that an idle game is mostly pure mechanics. Strip away art and story and what's left is a resource that accumulates on a timer, upgrades that raise the rate, and costs that scale so each purchase is a little harder than the last. That exponential tension — income grows, but prices grow faster — is the entire genre in one loop, and it fits comfortably in vanilla JavaScript: state in plain objects, a ticking update, and DOM updates when numbers change.
+
+Working without a framework was the refreshing part. Every abstraction I normally lean on — components, reactivity, bundling — exists to manage complexity, and a project this size has none to manage. The straight line from an idea to `script.js` to the browser is a feedback loop most modern web work has traded away.
+
+## What I'd do differently
+
+Balance with a spreadsheet, not with vibes. Idle games live or die on their numbers — how fast costs scale against income decides whether the game feels rewarding or stalls into a wall. I tuned mine by playing and nudging constants, which finds obvious problems and misses structural ones. Ten minutes modeling the curves would have shown exactly where progression flattened, before any code changed.
+
+## What broke
+
+The pacing, at the edges. A curve that felt right for the first stretch of play drifted at scale — eventually upgrades outran the cost scaling and the tension went slack. In a game whose only content is its numbers, a balance flaw isn't a detail; it is the game. Which was, in its own way, the perfect lesson for a one-sitting build: the code was the fast part. The design is where the time goes.

--- a/src/content/projects/instrument-tuner.mdx
+++ b/src/content/projects/instrument-tuner.mdx
@@ -1,0 +1,19 @@
+## The problem
+
+This started as me wanting a tuner that wasn't on my phone. I play five instruments, and every time I sat down to practice, tuning meant finding my phone, dismissing notifications, and opening an ad-covered app. A browser tab on the machine that's already open felt like the right home for it — and once the tuner worked, the project turned into a spot to keep all my music stuff.
+
+## The approach
+
+The app is a single page with four tabs, all built on the Web Audio API. The tuner does chromatic pitch detection against guitar and ukulele string targets, with a live needle gauge and automatic detection of which string you're playing. The note detector strips that down to a raw readout — closest note and frequency straight from the mic. The metronome covers 40 to 240 BPM with tap tempo, selectable time signatures, and a visual beat indicator.
+
+Then there's Metronome Duel, the part that exists purely because it was fun to build: a local hot-seat game where two players take turns matching or guessing a target tempo. A scoring engine converts tempo accuracy into damage, streaks multiply it, and a health-bar match runs until somebody wins.
+
+The architecture keeps all the signal and game logic — tempo math, duel scoring, click synthesis — in pure, framework-free modules with isolated unit tests, while React hooks own the stateful parts like mic analysis and playback. Alongside the tools, the site now hosts eight written guides on tuning technique, alternate tunings, and rhythm practice — you can read them at [music.crawfordyoung.dev/guides](https://music.crawfordyoung.dev/guides).
+
+## What I'd do differently
+
+Name it for what it became. The repo is still called InstrumentTuner, but the tuner is now one tab of four, plus a guide library. Scope grew honestly — each addition was something my own practice wanted — but the identity lagged behind, and renaming things later costs more than naming them loosely up front.
+
+## What broke
+
+The test suite, in a way that looked like the app. The end-to-end tests would intermittently fail across random guide pages with server errors — a different subset every run. The app was fine: production builds prerendered every route perfectly. The culprit was the dev server racing itself compiling several MDX routes at once on first load. The fix was making the suite retry once — a retried test runs alone, which is exactly the condition where the compile succeeds — plus a rule I've kept since: before debugging "broken pages," check whether the pages are broken or the harness is.

--- a/src/content/projects/portfolio-website.mdx
+++ b/src/content/projects/portfolio-website.mdx
@@ -1,0 +1,17 @@
+## The problem
+
+I needed a home on the web that actually shows what I do — not a résumé PDF with a URL, but a site whose own construction is part of the argument. If I'm going to claim I care about design systems, testing, and polish, the portfolio has to be built the way I build everything else, because it's the one project every visitor definitely sees.
+
+## The approach
+
+The site is Next.js with the App Router, deployed on Vercel, and it consumes my own component library — `@crawfordyoung/ui` — rather than one-off styled markup. That constraint is deliberate: if a page here needs something the library can't do, the library gets improved and republished instead of this repo growing a private fork. The design is dark-mode-first with a small set of signature effects — a spotlight header treatment and glow cards — built on Framer Motion, and every animation sits behind a reduced-motion guard.
+
+Under the hood it's a display site on purpose. No database, no auth, no server actions — the only dynamic data is GitHub stats fetched server-side at build time with incremental revalidation. The gates are the same as my application projects: full test coverage on the logic that's covered, Playwright end-to-end tests, axe accessibility checks in both themes, and Lighthouse held at 100 everywhere except performance, which relaxes to 90+ to pay for the motion work.
+
+## What I'd do differently
+
+Treat metadata as a feature from day one. Canonical URLs, Open Graph tags, and the sitemap arrived as their own dedicated pass long after the pages did, and retrofitting them meant auditing every route instead of adding one line per page as it was born. A page isn't done when it renders — it's done when a crawler and a link preview both understand it.
+
+## What broke
+
+The canonical-origin plumbing, in a way that was invisible locally. Next.js resolves relative metadata URLs against a `metadataBase`, and for a while that base was the only canonical configuration the site had — which emits nothing at all on its own. No canonical link, no `og:url`, on every page, while every local check passed because there was no wrong value to catch, just an absence. The fix pinned the site URL as a hardcoded constant in one module, made robots, sitemap, and metadata all derive from it, and added an end-to-end assertion that the served `og:url` matches. Absence is the failure mode that greps can't find — you have to assert presence.

--- a/src/content/projects/web-dev-club.mdx
+++ b/src/content/projects/web-dev-club.mdx
@@ -1,0 +1,19 @@
+## The problem
+
+As president of Auburn's Web Development Club, I kept running into the same gap: people would come to meetings interested in web development, watch a presentation, and leave without ever having built anything. Lectures don't make developers. What was missing was a low-stakes, recurring reason to actually write HTML, CSS, and JavaScript — small enough to finish in a week, real enough to be worth showing someone.
+
+## The approach
+
+The answer was weekly project challenges, all collected in one public repo organized by semester and week. Each week got a concrete, self-contained build: one week was a personal portfolio page, another was a to-do list app, and the semester built toward a larger project — a campus events site. Everything stayed deliberately close to the metal: plain HTML, CSS, and JavaScript, no frameworks, no build tooling, nothing to install beyond a text editor and a browser.
+
+That constraint was the point. A framework hides exactly the things a beginner needs to wrestle with — what the DOM actually is, why layout behaves the way it does, what happens on a click. Vanilla projects meant every member could open their file, refresh the browser, and see cause and effect with nothing in between. It also meant nobody spent their first meeting fighting a toolchain instead of building.
+
+Keeping it in a public repo mattered too. Members could look at how other people solved the same prompt, and everyone finished the semester with a small body of work that existed somewhere linkable rather than in a folder on their laptop.
+
+## What I'd do differently
+
+Build the on-ramp for the gaps. A weekly cadence is great for momentum and rough on anyone who misses two weeks — the challenges assumed you'd done the previous ones, and people who fell behind tended to stay behind. If I ran it again, each week would be genuinely standalone, with the connective tissue as optional stretch goals instead of prerequisites.
+
+## What broke
+
+Participation, before the format did. Early on, the challenges were described in meetings but not written down anywhere durable — so anyone who missed the meeting missed the week entirely. Moving everything into the repo, where each week's folder was the assignment, fixed more than organization: attendance stopped being the price of admission. The lesson generalizes — if the only copy of something lives in a meeting, it doesn't really exist.

--- a/src/content/writing/almost.mdx
+++ b/src/content/writing/almost.mdx
@@ -1,0 +1,88 @@
+import { Poem } from '@/components/writing/poem'
+
+# Almost
+
+These three poems are about connection that never quite lands — and I wrote them in the
+opposite order from how they sit here. *Chance* came first, in the winter of 2024, right
+after something real fell apart. *Strangers* followed that spring, when the rationalizing
+stopped working. *Wonder* came last, in the fall of 2025, my final semester at Auburn, when
+I'd finally found a gentler way to hold the whole thing. Reading them front to back walks
+the arc the other way: what could be, what was, what ended.
+
+*Wonder* is about the people you never meet. I'm more introvert than not, but I love keeping
+track of everyone around me, including people I've never spoken to. That last semester I kept
+recognizing faces — the same strangers crossing my path week after week, each one carrying an
+entire life I'd never know anything about. There's a comfort in that repetition, and a kind
+of beauty in letting them stay strangers.
+
+*Strangers* is the emotional side of the same ending *Chance* reasons about. In the moment,
+you can't stop the feelings by telling yourself something wasn't meant to be — the argument
+doesn't reach that far down. It also carries the other side of the argument, the one that's
+harder to say out loud: was it not meant to be, or was it a lack of effort?
+
+*Chance* is where it started. I didn't believe in coincidence until I met someone who made
+everything line up — the same obsessions, the same instruments coming back out after years,
+laughing to the point of tears. A connection that true feels like proof of something. But
+chance works in both ways, and some things just aren't meant to be. That's the harsh reality
+this one deals with, as plainly as I could manage.
+
+<h2 id="wonder" className="scroll-mt-24">
+  Wonder
+</h2>
+
+<Poem>{`As I walk by you down the street
+Or sit down in the same room
+My heart doesn't skip a beat
+And nothing between us will bloom
+
+I can't say we've ever spoke
+Not even a "good morning"
+I haven't seen you laugh at a joke
+Nor give a friend a warning
+
+Yet as I see your face
+I get a sense of comfort
+Because if we keep on passing by
+You might share my wonder`}</Poem>
+
+<h2 id="strangers" className="scroll-mt-24">
+  Strangers
+</h2>
+
+<Poem>{`She consumed every thought in my head
+And I'm not going to pretend she doesn't anymore
+But to her I might as well be dead
+And to me she isn't much more
+
+I know what we had was real
+Or at least the idea gives me comfort
+I know the circumstance wasn't ideal
+But I thought that we would come first
+
+So we slowly drift to strangers
+Our minds have been made up
+And I know I can't change hers
+Or even fill up my cup`}</Poem>
+
+<h2 id="chance" className="scroll-mt-24">
+  Chance
+</h2>
+
+<Poem>{`I didn't believe in coincidence until I met her
+Suddenly everything becomes one
+At first glance made my stomach stir
+My amount of doubts were none
+
+From the names of our future kids
+To the obsessions we held under lids
+Recreating the perfect girl in my head
+Must have been bound by thread
+
+Playing instruments that hadn't been used for years
+Laughing to the point of tears
+Talking about what makes us fulfilled
+I thought this feeling would never be killed
+
+But chance works in both ways
+Whether circumstance or daze
+Some things don't work`}</Poem>

--- a/src/content/writing/halfway-found.mdx
+++ b/src/content/writing/halfway-found.mdx
@@ -23,9 +23,11 @@ The collection takes its name from this poem's last line, because it's the hones
 stop: proud of what I've built, aware it isn't the whole job.
 
 *Role Model* started as a question a friend asked me on the phone — would you be a role model
-for the younger you? The intended answer is yes. Mine was more mixed. Younger me fell out of
-sports, kept some of his worst habits, and would have found me hard to recognize. But I am who
-I want to be, and he wouldn't understand me at all — and I couldn't be happier about that.
+for the younger you? What surprised me was how far the honest answer outran the question.
+Younger me was certain the world was horrible, that suffering was inevitable, that there was
+no one out there to truly embrace. He wasn't wrong to think it — but I've become someone he
+never thought was possible. I am who I want to be, better than anything he dared to imagine,
+and he wouldn't understand me at all. I couldn't be happier about that.
 
 <h2 id="waiting" className="scroll-mt-24">
   Waiting

--- a/src/content/writing/halfway-found.mdx
+++ b/src/content/writing/halfway-found.mdx
@@ -1,0 +1,98 @@
+import { Poem } from '@/components/writing/poem'
+
+# Halfway Found
+
+These are the newest poems here, written between spring 2025 and summer 2026, and they all
+circle the same habit: auditing myself against a standard I set, and noticing what that audit
+does to me. I've spent my whole life working on myself in one way or another. Somewhere along
+the way I started asking whether the working ever counts as arriving — whether I'd recognize
+the finished version if I met him. These three are attempts at that question from different
+angles.
+
+*Waiting* is the most recent, from summer 2026. Every excuse in it is one I've actually used,
+and that's the trap — they all sound legitimate. We convince ourselves it's fine to skip the
+more important thing because the conditions aren't right yet. Part of loving yourself is
+pushing yourself to do all of it anyway, and part of it is noticing how long you've been
+waiting on conditions that were never the point.
+
+*Paradox* came out of a winter spent wondering why I've always seen myself as a person who
+doesn't make sense. I loved tech but I was athletic. People read me as cool while I carried
+horrible social anxiety. Eventually I realized I wasn't just noticing the contradiction — I
+had been building it on purpose, because being hard to comprehend felt like a way to matter.
+The collection takes its name from this poem's last line, because it's the honest place to
+stop: proud of what I've built, aware it isn't the whole job.
+
+*Role Model* started as a question a friend asked me on the phone — would you be a role model
+for the younger you? The intended answer is yes. Mine was more mixed. Younger me fell out of
+sports, kept some of his worst habits, and would have found me hard to recognize. But I am who
+I want to be, and he wouldn't understand me at all — and I couldn't be happier about that.
+
+<h2 id="waiting" className="scroll-mt-24">
+  Waiting
+</h2>
+
+<Poem>{`When I have this or
+No longer have that
+Have something to provide for
+Or when my wallet is fat
+
+When I don't have work
+Or put down the fork
+When I truly follow through
+On the things I said I'd do
+
+When friends aren't busy
+And I'm not dizzy
+When I don't sink in the couch
+Or am not next to a grouch
+
+When I get out of bed and
+love the guy in the mirror.`}</Poem>
+
+<h2 id="paradox" className="scroll-mt-24">
+  Paradox
+</h2>
+
+<Poem>{`I wanted friends to call my own
+Ones who loved me for who I was
+Yet I spent my time sitting alone
+Trying to become a paradox because
+
+I thought if I were different
+Or far beyond comprehension
+I'd be someone's parent
+Or have some loving tension
+
+I found the feeling I asked for
+What it means to be unique
+Though my value is far from poor
+I have one critique
+
+Though you love yourself
+You aren't anything with no one around
+Take those trophies off the shelf
+You are only halfway found`}</Poem>
+
+<h2 id="role-model" className="scroll-mt-24">
+  Role Model
+</h2>
+
+<Poem>{`"Would you be a role model for the younger you?"
+This question took a while to answer
+All of the things he wanted that I didn't do
+I fell out of sports and didn't cure cancer
+
+The boy who thought the world was a horrible place
+Where suffering was inevitable and overwhelming
+Where it's impossible to find someone to truly embrace
+And what he said was pretty compelling
+
+He wasn't even that far from the truth
+I still only work if push comes to shove
+I haven't broke the habits from my youth
+I can't pretend I have someone to love
+
+But I am who I want to be
+Even if it's crappier
+He wouldn't even understand me
+And I couldn't be happier`}</Poem>

--- a/src/content/writing/the-hiker.mdx
+++ b/src/content/writing/the-hiker.mdx
@@ -1,0 +1,87 @@
+# The Hiker
+
+*This story is a meditation on effort, responsibility, and choice. I was interested in how
+paths form — not just through intention, but through repetition, hesitation, and the quiet
+decisions we make when no one is watching. The hiker's journey is not about reaching a
+summit, but about recognizing what different heights ask of us, and deciding where we are
+willing to remain. Some places demand everything and give little in return. Others change
+when we pass through them, and change us in turn.*
+
+He could not remember deciding to climb—only that he was already on the path, moving with
+others, his feet following a direction his mind had not yet questioned. The trail was wide
+here, smoothed by countless steps, welcoming sound that carried easily between the trees.
+Voices rose and fell in laughter and instruction, the scrape of boots against stone marking
+each moment without urgency. People moved in clusters, adjusting packs and pointing ahead,
+stopping to rest without worry. The ground bore the marks of familiarity, pressed flat and
+forgiving, as if it had learned where to yield.
+
+He moved carefully among them.
+
+He stepped around shallow puddles, avoided edges where grass clung stubbornly, shifted his
+weight when the soil felt soft. When passing others, he slowed, giving space, nodding without
+meeting anyone's eyes. The mountain was generous here, and so were they. Nothing demanded
+him; nothing required him. Yet he could not stop walking. Something unspoken pressed him
+forward, each step following the last as though the trail itself were pulling him onward.
+
+The voices thinned first. Greetings shortened to nods; nods to silence. Groups broke apart.
+Some turned back, their footsteps retreating until they were swallowed by distance. Others
+pressed on without speaking, faces set forward, breath measured. The trail narrowed. Rocks
+replaced soil. Roots twisted across the path, gripping, tripping, forcing attention to the
+ground. Every step asked for care, for observation. The ease of the lower trail had vanished.
+
+Here, he began to feel the weight of each movement.
+
+The mountain grew more exacting. Stone fractured beneath pressure, air thinned, patience
+thinned with it. The path—once obvious—threaded between danger. Deviating was no longer
+harmless; a misplaced step could send him sliding, scraping, falling. And yet, the path
+remained, faint but steadfast. Each subtle marker—a shifted stone, a worn edge—spoke of those
+who had come before, of choices made carefully and survived. He followed them closely,
+attentive, aware that small missteps here would leave consequences far greater than before.
+
+Time stretched. Each step became a measured decision, each breath a small effort. Alone, his
+thoughts arrived unbidden and lingered, reflecting hesitation, doubt, the weight of the
+climb. Why continue? What demanded him to go forward? And yet he moved. Slowly. Precisely.
+Forward, because the mountain held him, and the trail would not allow pause.
+
+Near the summit, the wind cut sharply. The path thinned, clinging to the side of the
+mountain. One misstep would have consequences he could not ignore. The land here asked
+nothing of him, but required his full attention. He paused at the edge of a faint line where
+the trail threatened to disappear. Stones had shifted, weather had worn the markers away. He
+set them back, pressed them down, made the line visible again. A small act. Unheroic.
+Necessary. Enough to guide anyone who might follow.
+
+The summit opened before him, vast and indifferent. The world unfolded in abstract distance,
+and he felt neither triumph nor dread—only neutrality. The view demanded attention, yet
+offered no comfort. Nothing grew easily. Nothing lingered. The wind erased what it could. He
+understood, standing there, that surviving this height required effort beyond measure and
+returned very little. This was not a place to live. It was a place to pass through, endure
+long enough to leave something behind, and then depart.
+
+He stayed only as long as needed.
+
+The descent softened gradually. The path became less precarious. Danger loosened its grip. He
+stepped off the trail once, then again—not careless, but unafraid. A small plant bent beneath
+his boot and rose again, returning to its form as if nothing had happened. The mountain
+accepted his disturbance without judgment.
+
+Lower still, the sound of water returned.
+
+He recognized the river now, wider than he remembered, its banks etched by time—stones
+smoothed, channels reshaped by countless crossings. It had been changed, again and again, yet
+it remained unmistakably itself. He knelt at the edge and drank, the water cold and clear.
+Later, he washed his hands and his face, letting the current carry the moment away. The river
+clouded briefly, then cleared. It did not resist him. It did not require permission.
+
+He watched it for a long time, noting how it carried everything forward, shaping the land
+without hesitation, without need for recognition. From this vantage, the summit path above
+was invisible, but he knew it was there—waiting for those who would choose it, for those who
+would require the clarity left behind by others who had passed through.
+
+He remained by the river as the light shifted, feeling no urgency to move on, no certainty
+about what would come next. Only the quiet knowledge that some paths are meant to be walked
+briefly, and others revisited. Some exertion is temporary, some guidance necessary, some
+presence fleeting. And in that understanding, he found a sort of balance: an acceptance
+without certainty.
+
+The river continued its work, carrying what it was given, shaping the land, and
+nearby—higher, harder—the path held.

--- a/src/content/writing/you-cant-halfway-jump.mdx
+++ b/src/content/writing/you-cant-halfway-jump.mdx
@@ -1,0 +1,122 @@
+import { Poem } from '@/components/writing/poem'
+
+# You Can't Halfway Jump
+
+All four of these come from one stretch of 2024 — my last summer at Camp Rockmont, where I'd
+spent eight years as a camper and was back for my second summer on staff, and the first fall
+after it. Everything that year had the same shape: an ending I could see coming, a next stage
+I couldn't see at all, and the growing understanding that you don't get to ease into either
+one. Commit, endure, savor the ending, accept the unknown — that's the order they sit in
+here, and it's more or less the order the year taught them to me.
+
+*Paradise Falls* is a real place, a cliff-jumping spot in North Carolina. I'm terrified of
+heights, and I actually jumped — shaking from head to toe, exactly like the poem says. But it
+was never only about the cliff. That summer was about having to fully commit to whatever came
+next in life without knowing what it was, and standing on that edge was the closest physical
+thing to how that felt. The poem came before the song, but the same jump ended up in both.
+
+*Light at the End of the Tunnel* is about resilience — keeping on doing what you think is
+right regardless of the situation, even when the thing you were promised at the end stops
+being visible. It's also built to be read in reverse; going backward, it might just be
+getting easier.
+
+*Enjoy These Last Moments* repeats its own title the way the phrase got repeated at me.
+"Enjoy this while you're young" gets said constantly, and the grass is always greener, so the
+last moments keep on happening. The repetition is the point — fight for every moment so it's
+the best it can be, and think about what you want to leave behind.
+
+*Souls* came after reading Cicero on living and dying well, which has a bit about souls.
+Stepping back far enough, life is absurd, and there's a lot no one knows. This one is my
+acceptance of that.
+
+<h2 id="paradise-falls" className="scroll-mt-24">
+  Paradise Falls
+</h2>
+
+<Poem>{`You know you have to jump
+Easier said than done
+What if there's rocks, a tree, a stump
+Making the water below not fun
+
+You look over the edge
+Shaking from head to toe
+Making yourself take a pledge
+It'd be better if you'd just go
+
+You can't halfway jump
+You have to commit to one
+If you stay you're a chump
+If you go you'll have won
+
+You jump
+Then you're at the bottom
+Feeling so pumped
+And you almost waited until autumn`}</Poem>
+
+[Hear the CarsickYak cover of this one](https://carsickyak.crawfordyoung.dev/covers)
+
+<h2 id="light-at-the-end-of-the-tunnel" className="scroll-mt-24">
+  Light at the End of the Tunnel
+</h2>
+
+<Poem>{`The light at the end of the tunnel
+I know what I'm supposed to do
+Not even a second is trouble
+I just have to make it through
+
+The light is getting smaller
+I might be able to squeeze out
+If only I wasn't taller
+But at least I'm devout
+
+The light is gone
+But at least I have the tunnel
+Taking step after step
+This might take a while
+
+I can't see
+I don't know if I'm right
+But I'm still trying
+I'm still trying`}</Poem>
+
+<h2 id="enjoy-these-last-moments" className="scroll-mt-24">
+  Enjoy These Last Moments
+</h2>
+
+<Poem>{`Enjoy these last moments
+Don't let goodbyes give you a fright
+Enjoy these last moments
+But don't go quietly into the night
+
+Enjoy these last moments
+Try with all your might
+Enjoy these last moments
+Though the end skews your sight
+
+Enjoy these last moments
+The days go by fast
+Enjoy these last moments
+Today's now your last
+
+Have you decided what rules to abide?
+Have you left the world signed?
+What is on the other side?
+What do you leave behind?`}</Poem>
+
+<h2 id="souls" className="scroll-mt-24">
+  Souls
+</h2>
+
+<Poem>{`What keeps a human going
+Other than its blood flowing?
+
+Souls are the answer given by most
+Which to them I would give a toast
+
+Created by conception or always there?
+Does it have to do with the way we care?
+
+Are they malleable, ranging,
+Or spiritually unchanging?
+
+No one knows.`}</Poem>

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -51,7 +51,6 @@ export const projects: Project[] = [
     description:
       "AI that analyses player game history and assigns personalised puzzles targeting each player's weaknesses.",
     tech: ['Python', 'AI/ML'],
-    repo: 'https://github.com/Crawford-Young/ChessBot',
   },
   {
     slug: 'instrument-tuner',

--- a/src/data/writing.ts
+++ b/src/data/writing.ts
@@ -1,0 +1,72 @@
+import { z } from 'zod'
+
+export const PoemSchema = z.object({
+  anchor: z.string().regex(/^[a-z0-9-]+$/),
+  title: z.string().min(1),
+})
+
+export const CollectionSchema = z.object({
+  slug: z.string().regex(/^[a-z0-9-]+$/),
+  title: z.string().min(1),
+  description: z.string().min(10),
+  order: z.number().int().positive(),
+  poems: z.array(PoemSchema).min(3),
+})
+
+export type Poem = z.infer<typeof PoemSchema>
+export type Collection = z.infer<typeof CollectionSchema>
+
+export const collections: readonly Collection[] = [
+  {
+    slug: 'halfway-found',
+    title: 'Halfway Found',
+    description:
+      'Three poems about auditing yourself against a standard you set — the conditions we put on self-love, becoming a contradiction on purpose, and the younger self as judge.',
+    order: 1,
+    poems: [
+      { anchor: 'waiting', title: 'Waiting' },
+      { anchor: 'paradox', title: 'Paradox' },
+      { anchor: 'role-model', title: 'Role Model' },
+    ],
+  },
+  {
+    slug: 'almost',
+    title: 'Almost',
+    description:
+      'Three states of near-connection — the stranger who might be something, the drift back into being strangers, and the chance that didn’t hold.',
+    order: 2,
+    poems: [
+      { anchor: 'wonder', title: 'Wonder' },
+      { anchor: 'strangers', title: 'Strangers' },
+      { anchor: 'chance', title: 'Chance' },
+    ],
+  },
+  {
+    slug: 'you-cant-halfway-jump',
+    title: "You Can't Halfway Jump",
+    description:
+      'Four poems from one year — commit to the jump, keep walking when the light goes, savor the ending, and accept what nobody knows.',
+    order: 3,
+    poems: [
+      { anchor: 'paradise-falls', title: 'Paradise Falls' },
+      { anchor: 'light-at-the-end-of-the-tunnel', title: 'Light at the End of the Tunnel' },
+      { anchor: 'enjoy-these-last-moments', title: 'Enjoy These Last Moments' },
+      { anchor: 'souls', title: 'Souls' },
+    ],
+  },
+]
+
+export const STORY = {
+  slug: 'the-hiker',
+  title: 'The Hiker',
+  description:
+    'A short story about effort, responsibility, and choice — what different heights ask of us, and where we are willing to remain.',
+} as const
+
+export function writingSlugs(): readonly string[] {
+  return [...collections.map((c) => c.slug), STORY.slug]
+}
+
+export function writingPath(slug: string): string {
+  return `/writing/${slug}`
+}

--- a/src/lib/site-routes.ts
+++ b/src/lib/site-routes.ts
@@ -10,6 +10,7 @@ export const STATIC_ROUTES: readonly string[] = [
   '/experience',
   '/hobbies',
   '/writing',
+  '/about',
   '/privacy',
   '/contact',
 ]

--- a/src/lib/site-routes.ts
+++ b/src/lib/site-routes.ts
@@ -1,5 +1,6 @@
 import type { MetadataRoute } from 'next'
 import { projects } from '@/data/projects'
+import { writingPath, writingSlugs } from '@/data/writing'
 
 export const SITE_URL = 'https://crawfordyoung.dev'
 
@@ -8,12 +9,17 @@ export const STATIC_ROUTES: readonly string[] = [
   '/projects',
   '/experience',
   '/hobbies',
+  '/writing',
   '/privacy',
   '/contact',
 ]
 
 export function siteRoutes(): readonly string[] {
-  return [...STATIC_ROUTES, ...projects.map((project) => `/projects/${project.slug}`)]
+  return [
+    ...STATIC_ROUTES,
+    ...projects.map((project) => `/projects/${project.slug}`),
+    ...writingSlugs().map((slug) => writingPath(slug)),
+  ]
 }
 
 export function buildSitemap(lastModified: Date): MetadataRoute.Sitemap {

--- a/src/lib/writing-content.ts
+++ b/src/lib/writing-content.ts
@@ -4,11 +4,16 @@ import { join } from 'node:path'
 export const COLLECTION_MIN_WORDS = 400
 export const STORY_MIN_WORDS = 800
 export const PROJECT_MIN_WORDS = 300
+export const ABOUT_MIN_WORDS = 350
 
 const CONTENT_DIR = join(process.cwd(), 'src', 'content')
 
 export function readContentSource(dir: 'writing' | 'projects', slug: string): string {
   return readFileSync(join(CONTENT_DIR, dir, `${slug}.mdx`), 'utf8')
+}
+
+export function readAboutSource(): string {
+  return readFileSync(join(CONTENT_DIR, 'about.mdx'), 'utf8')
 }
 
 // Ported from instrumenttuner src/lib/guide-content.ts (adsense-w2), with `{}` added to the

--- a/src/lib/writing-content.ts
+++ b/src/lib/writing-content.ts
@@ -1,0 +1,23 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+export const COLLECTION_MIN_WORDS = 400
+export const STORY_MIN_WORDS = 800
+export const PROJECT_MIN_WORDS = 300
+
+const CONTENT_DIR = join(process.cwd(), 'src', 'content')
+
+export function readContentSource(dir: 'writing' | 'projects', slug: string): string {
+  return readFileSync(join(CONTENT_DIR, dir, `${slug}.mdx`), 'utf8')
+}
+
+// Ported from instrumenttuner src/lib/guide-content.ts (adsense-w2), with `{}` added to the
+// strip class so Poem template-literal braces don't count as tokens.
+export function countWords(mdx: string): number {
+  const stripped = mdx
+    .replace(/```[\s\S]*?```/g, ' ')
+    .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/[#*_>`|~{}]/g, ' ')
+  return stripped.split(/\s+/).filter((token) => /[\p{L}\p{N}]/u.test(token)).length
+}

--- a/src/mdx-components.tsx
+++ b/src/mdx-components.tsx
@@ -1,0 +1,7 @@
+import type { MDXComponents } from 'mdx/types'
+
+const components: MDXComponents = {}
+
+export function useMDXComponents(): MDXComponents {
+  return components
+}

--- a/tests/e2e/writing.spec.ts
+++ b/tests/e2e/writing.spec.ts
@@ -1,0 +1,43 @@
+import { test, expect } from '@playwright/test'
+import { SITE_URL } from '@/lib/site-routes'
+import { collections } from '@/data/writing'
+
+test('writing hub lists the collections and the story', async ({ page }) => {
+  await page.goto('/writing')
+  await expect(page.getByRole('heading', { name: 'Writing', level: 1 })).toBeVisible()
+  await expect(page.getByText('Halfway Found')).toBeVisible()
+  await expect(page.getByText('The Hiker')).toBeVisible()
+})
+
+test('every collection serves its poem anchors and canonical url', async ({ page }) => {
+  for (const collection of collections) {
+    await page.goto(`/writing/${collection.slug}`)
+    for (const poem of collection.poems) {
+      await expect(page.locator(`#${poem.anchor}`)).toBeVisible()
+    }
+    const canonical = await page.locator('link[rel="canonical"]').getAttribute('href')
+    expect(canonical).toBe(`${SITE_URL}/writing/${collection.slug}`)
+  }
+})
+
+test('the hiker is served with its canonical url', async ({ page }) => {
+  await page.goto('/writing/the-hiker')
+  await expect(page.getByRole('heading', { name: 'The Hiker', level: 1 })).toBeVisible()
+  const canonical = await page.locator('link[rel="canonical"]').getAttribute('href')
+  expect(canonical).toBe(`${SITE_URL}/writing/the-hiker`)
+})
+
+test('sitemap lists the writing routes', async ({ request }) => {
+  const xml = await (await request.get('/sitemap.xml')).text()
+  expect(xml).toContain(`${SITE_URL}/writing`)
+  expect(xml).toContain(`${SITE_URL}/writing/the-hiker`)
+})
+
+test('nav reaches writing', async ({ page }) => {
+  await page.goto('/')
+  await page
+    .getByRole('navigation', { name: 'Main' })
+    .getByRole('link', { name: 'Writing' })
+    .click()
+  await expect(page).toHaveURL('/writing')
+})

--- a/tests/e2e/writing.spec.ts
+++ b/tests/e2e/writing.spec.ts
@@ -46,3 +46,16 @@ test('nav reaches writing', async ({ page }) => {
     .click()
   await expect(page).toHaveURL('/writing')
 })
+
+test('about page is served with its canonical url', async ({ page }) => {
+  await page.goto('/about')
+  await expect(page.getByRole('heading', { name: 'About', level: 1 })).toBeVisible()
+  const canonical = await page.locator('link[rel="canonical"]').getAttribute('href')
+  expect(canonical).toBe(`${SITE_URL}/about`)
+})
+
+test('nav reaches about', async ({ page }) => {
+  await page.goto('/')
+  await page.getByRole('navigation', { name: 'Main' }).getByRole('link', { name: 'About' }).click()
+  await expect(page).toHaveURL('/about')
+})

--- a/tests/e2e/writing.spec.ts
+++ b/tests/e2e/writing.spec.ts
@@ -33,6 +33,11 @@ test('sitemap lists the writing routes', async ({ request }) => {
   expect(xml).toContain(`${SITE_URL}/writing/the-hiker`)
 })
 
+test('project pages render the write-up prose', async ({ page }) => {
+  await page.goto('/projects/component-library')
+  await expect(page.getByRole('heading', { level: 2 }).first()).toBeVisible()
+})
+
 test('nav reaches writing', async ({ page }) => {
   await page.goto('/')
   await page

--- a/tests/unit/nav.test.tsx
+++ b/tests/unit/nav.test.tsx
@@ -6,7 +6,7 @@ import { PillNav } from '@/components/layout/nav'
 vi.mock('next/navigation', () => ({ usePathname: () => '/' }))
 
 describe('PillNav', () => {
-  it('renders the 5 nav links with correct hrefs', () => {
+  it('renders the 6 nav links with correct hrefs, About last', () => {
     render(<PillNav />)
     const homeLinks = screen.getAllByRole('link', { name: 'Home' })
     expect(homeLinks[0]).toHaveAttribute('href', '/')
@@ -18,6 +18,11 @@ describe('PillNav', () => {
     expect(hobbiesLinks[0]).toHaveAttribute('href', '/hobbies')
     const experienceLinks = screen.getAllByRole('link', { name: 'Experience' })
     expect(experienceLinks[0]).toHaveAttribute('href', '/experience')
+    const aboutLinks = screen.getAllByRole('link', { name: 'About' })
+    expect(aboutLinks[0]).toHaveAttribute('href', '/about')
+    const desktopNav = screen.getByRole('navigation', { name: 'Main' })
+    const desktopLabels = Array.from(desktopNav.querySelectorAll('a')).map((a) => a.textContent)
+    expect(desktopLabels).toEqual(['Home', 'Projects', 'Writing', 'Hobbies', 'Experience', 'About'])
     expect(screen.queryByRole('link', { name: 'Contact' })).not.toBeInTheDocument()
   })
 

--- a/tests/unit/nav.test.tsx
+++ b/tests/unit/nav.test.tsx
@@ -6,12 +6,14 @@ import { PillNav } from '@/components/layout/nav'
 vi.mock('next/navigation', () => ({ usePathname: () => '/' }))
 
 describe('PillNav', () => {
-  it('renders the 4 nav links with correct hrefs', () => {
+  it('renders the 5 nav links with correct hrefs', () => {
     render(<PillNav />)
     const homeLinks = screen.getAllByRole('link', { name: 'Home' })
     expect(homeLinks[0]).toHaveAttribute('href', '/')
     const projectsLinks = screen.getAllByRole('link', { name: 'Projects' })
     expect(projectsLinks[0]).toHaveAttribute('href', '/projects')
+    const writingLinks = screen.getAllByRole('link', { name: 'Writing' })
+    expect(writingLinks[0]).toHaveAttribute('href', '/writing')
     const hobbiesLinks = screen.getAllByRole('link', { name: 'Hobbies' })
     expect(hobbiesLinks[0]).toHaveAttribute('href', '/hobbies')
     const experienceLinks = screen.getAllByRole('link', { name: 'Experience' })

--- a/tests/unit/poem.test.tsx
+++ b/tests/unit/poem.test.tsx
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest'
+import { render } from '@testing-library/react'
+import { Poem } from '@/components/writing/poem'
+
+describe('Poem', () => {
+  it('preserves line breaks via pre-line whitespace', () => {
+    const { container } = render(<Poem>{'one\ntwo'}</Poem>)
+    const el = container.firstElementChild
+    expect(el?.textContent).toBe('one\ntwo')
+    expect(el?.className).toContain('whitespace-pre-line')
+  })
+})

--- a/tests/unit/poem.test.tsx
+++ b/tests/unit/poem.test.tsx
@@ -9,4 +9,12 @@ describe('Poem', () => {
     expect(el?.textContent).toBe('one\ntwo')
     expect(el?.className).toContain('whitespace-pre-line')
   })
+
+  it('renders as a card panel', () => {
+    const { container } = render(<Poem>{'one\ntwo'}</Poem>)
+    const el = container.firstElementChild
+    expect(el?.className).toContain('rounded-xl')
+    expect(el?.className).toContain('border')
+    expect(el?.className).toContain('bg-surface/40')
+  })
 })

--- a/tests/unit/site-routes.test.ts
+++ b/tests/unit/site-routes.test.ts
@@ -16,6 +16,7 @@ describe('site-routes', () => {
         '/experience',
         '/hobbies',
         '/writing',
+        '/about',
         '/privacy',
         '/contact',
       ])

--- a/tests/unit/site-routes.test.ts
+++ b/tests/unit/site-routes.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { SITE_URL, siteRoutes, buildSitemap } from '@/lib/site-routes'
 import { projects } from '@/data/projects'
+import { writingSlugs, writingPath } from '@/data/writing'
 
 describe('site-routes', () => {
   it('points at the apex domain', () => {
@@ -9,7 +10,15 @@ describe('site-routes', () => {
 
   it('includes every static route', () => {
     expect(siteRoutes()).toEqual(
-      expect.arrayContaining(['/', '/projects', '/experience', '/hobbies', '/privacy', '/contact'])
+      expect.arrayContaining([
+        '/',
+        '/projects',
+        '/experience',
+        '/hobbies',
+        '/writing',
+        '/privacy',
+        '/contact',
+      ])
     )
   })
 
@@ -17,6 +26,13 @@ describe('site-routes', () => {
     const routes = siteRoutes()
     for (const project of projects) {
       expect(routes).toContain(`/projects/${project.slug}`)
+    }
+  })
+
+  it('includes a route for every writing piece', () => {
+    const routes = siteRoutes()
+    for (const slug of writingSlugs()) {
+      expect(routes).toContain(writingPath(slug))
     }
   })
 
@@ -32,6 +48,15 @@ describe('site-routes', () => {
     for (const entry of entries) {
       expect(entry.url.startsWith('https://crawfordyoung.dev')).toBe(true)
       expect(entry.url.endsWith('/')).toBe(false)
+    }
+  })
+
+  it('builds absolute sitemap urls for every writing route', () => {
+    const now = new Date('2026-07-28T00:00:00.000Z')
+    const entries = buildSitemap(now)
+    const urls = entries.map((e) => e.url)
+    for (const slug of writingSlugs()) {
+      expect(urls).toContain(`https://crawfordyoung.dev${writingPath(slug)}`)
     }
   })
 })

--- a/tests/unit/writing-content.test.ts
+++ b/tests/unit/writing-content.test.ts
@@ -2,6 +2,7 @@ import { readdirSync } from 'node:fs'
 import { join } from 'node:path'
 import { compile } from '@mdx-js/mdx'
 import { describe, it, expect } from 'vitest'
+import { projects } from '@/data/projects'
 import { collections, STORY, writingSlugs } from '@/data/writing'
 import {
   COLLECTION_MIN_WORDS,
@@ -72,6 +73,24 @@ describe('writing content files', () => {
   it('no orphan writing files outside the registry', () => {
     const files = readdirSync(join(process.cwd(), 'src', 'content', 'writing'))
     const slugs = new Set(writingSlugs())
+    for (const file of files) {
+      expect(slugs.has(file.replace(/\.mdx$/, '')), file).toBe(true)
+    }
+  })
+})
+
+describe('project write-ups', () => {
+  it('every project has a write-up that compiles and meets the floor', async () => {
+    for (const project of projects) {
+      const source = readContentSource('projects', project.slug)
+      await expect(compile(source), project.slug).resolves.toBeDefined()
+      expect(countWords(source), project.slug).toBeGreaterThanOrEqual(PROJECT_MIN_WORDS)
+    }
+  })
+
+  it('no orphan project write-ups', () => {
+    const files = readdirSync(join(process.cwd(), 'src', 'content', 'projects'))
+    const slugs = new Set(projects.map((p) => p.slug))
     for (const file of files) {
       expect(slugs.has(file.replace(/\.mdx$/, '')), file).toBe(true)
     }

--- a/tests/unit/writing-content.test.ts
+++ b/tests/unit/writing-content.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest'
+import {
+  COLLECTION_MIN_WORDS,
+  countWords,
+  PROJECT_MIN_WORDS,
+  readContentSource,
+  STORY_MIN_WORDS,
+} from '@/lib/writing-content'
+
+describe('countWords', () => {
+  it('counts prose words, not markup', () => {
+    expect(countWords('# Title\n\nTwo words [link text](/writing/x) *here*.')).toBe(6)
+  })
+
+  it('counts poem lines inside a Poem template literal, not the braces', () => {
+    expect(countWords('<Poem>{`one line\ntwo more`}</Poem>')).toBe(4)
+  })
+})
+
+describe('floors', () => {
+  it('are the plan constants', () => {
+    expect(COLLECTION_MIN_WORDS).toBe(400)
+    expect(STORY_MIN_WORDS).toBe(800)
+    expect(PROJECT_MIN_WORDS).toBe(300)
+  })
+})
+
+describe('readContentSource', () => {
+  it('throws for a missing source file', () => {
+    expect(() => readContentSource('writing', 'not-a-real-slug')).toThrow()
+  })
+})

--- a/tests/unit/writing-content.test.ts
+++ b/tests/unit/writing-content.test.ts
@@ -5,9 +5,11 @@ import { describe, it, expect } from 'vitest'
 import { projects } from '@/data/projects'
 import { collections, STORY, writingSlugs } from '@/data/writing'
 import {
+  ABOUT_MIN_WORDS,
   COLLECTION_MIN_WORDS,
   countWords,
   PROJECT_MIN_WORDS,
+  readAboutSource,
   readContentSource,
   STORY_MIN_WORDS,
 } from '@/lib/writing-content'
@@ -76,6 +78,14 @@ describe('writing content files', () => {
     for (const file of files) {
       expect(slugs.has(file.replace(/\.mdx$/, '')), file).toBe(true)
     }
+  })
+})
+
+describe('about page content', () => {
+  it('compiles as MDX and meets the word floor', async () => {
+    const source = readAboutSource()
+    await expect(compile(source)).resolves.toBeDefined()
+    expect(countWords(source)).toBeGreaterThanOrEqual(ABOUT_MIN_WORDS)
   })
 })
 

--- a/tests/unit/writing-content.test.ts
+++ b/tests/unit/writing-content.test.ts
@@ -1,4 +1,8 @@
+import { readdirSync } from 'node:fs'
+import { join } from 'node:path'
+import { compile } from '@mdx-js/mdx'
 import { describe, it, expect } from 'vitest'
+import { collections, STORY, writingSlugs } from '@/data/writing'
 import {
   COLLECTION_MIN_WORDS,
   countWords,
@@ -28,5 +32,48 @@ describe('floors', () => {
 describe('readContentSource', () => {
   it('throws for a missing source file', () => {
     expect(() => readContentSource('writing', 'not-a-real-slug')).toThrow()
+  })
+})
+
+describe('writing content files', () => {
+  it('every writing slug has a source file that compiles as MDX', async () => {
+    for (const slug of writingSlugs()) {
+      await expect(compile(readContentSource('writing', slug)), slug).resolves.toBeDefined()
+    }
+  })
+
+  it('every collection page carries its poem anchors', () => {
+    for (const collection of collections) {
+      const source = readContentSource('writing', collection.slug)
+      for (const poem of collection.poems) {
+        expect(source, `${collection.slug}#${poem.anchor}`).toContain(`id="${poem.anchor}"`)
+      }
+    }
+  })
+
+  it('every collection meets the word floor', () => {
+    for (const collection of collections) {
+      const words = countWords(readContentSource('writing', collection.slug))
+      expect(words, collection.slug).toBeGreaterThanOrEqual(COLLECTION_MIN_WORDS)
+    }
+  })
+
+  it('the story meets its floor', () => {
+    const words = countWords(readContentSource('writing', STORY.slug))
+    expect(words).toBeGreaterThanOrEqual(STORY_MIN_WORDS)
+  })
+
+  it('the paradise falls collection links to the carsickyak cover', () => {
+    expect(readContentSource('writing', 'you-cant-halfway-jump')).toContain(
+      'https://carsickyak.crawfordyoung.dev'
+    )
+  })
+
+  it('no orphan writing files outside the registry', () => {
+    const files = readdirSync(join(process.cwd(), 'src', 'content', 'writing'))
+    const slugs = new Set(writingSlugs())
+    for (const file of files) {
+      expect(slugs.has(file.replace(/\.mdx$/, '')), file).toBe(true)
+    }
   })
 })

--- a/tests/unit/writing-data.test.ts
+++ b/tests/unit/writing-data.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest'
+import { collections, CollectionSchema, STORY, writingPath, writingSlugs } from '@/data/writing'
+
+describe('writing registry', () => {
+  it('has the three approved collections in order', () => {
+    expect(collections.map((c) => c.slug)).toEqual([
+      'halfway-found',
+      'almost',
+      'you-cant-halfway-jump',
+    ])
+  })
+
+  it('every collection satisfies the schema', () => {
+    for (const collection of collections) {
+      expect(() => CollectionSchema.parse(collection)).not.toThrow()
+    }
+  })
+
+  it('carries all ten poems under their agreed substack-canonical anchors', () => {
+    const anchors = collections.flatMap((c) => c.poems.map((p) => `${c.slug}#${p.anchor}`))
+    expect(anchors).toEqual([
+      'halfway-found#waiting',
+      'halfway-found#paradox',
+      'halfway-found#role-model',
+      'almost#wonder',
+      'almost#strangers',
+      'almost#chance',
+      'you-cant-halfway-jump#paradise-falls',
+      'you-cant-halfway-jump#light-at-the-end-of-the-tunnel',
+      'you-cant-halfway-jump#enjoy-these-last-moments',
+      'you-cant-halfway-jump#souls',
+    ])
+  })
+
+  it('writingSlugs lists collections then the story', () => {
+    expect(writingSlugs()).toEqual([
+      'halfway-found',
+      'almost',
+      'you-cant-halfway-jump',
+      'the-hiker',
+    ])
+  })
+
+  it('writingPath builds the route', () => {
+    expect(writingPath(STORY.slug)).toBe('/writing/the-hiker')
+  })
+})

--- a/tests/unit/writing-hub.test.tsx
+++ b/tests/unit/writing-hub.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import WritingPage from '@/app/writing/page'
+
+vi.mock('@/components/effects/spotlight', () => ({
+  Spotlight: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+vi.mock('@/components/effects/glow-card', () => ({
+  GlowCard: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+
+describe('WritingPage', () => {
+  it('renders heading', () => {
+    render(<WritingPage />)
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('Writing')
+  })
+
+  it('renders all three collections and the story', () => {
+    render(<WritingPage />)
+    expect(screen.getByText('Halfway Found')).toBeInTheDocument()
+    expect(screen.getByText('Almost')).toBeInTheDocument()
+    expect(screen.getByText("You Can't Halfway Jump")).toBeInTheDocument()
+    expect(screen.getByText('The Hiker')).toBeInTheDocument()
+  })
+
+  it('links each collection card to its writing route', () => {
+    render(<WritingPage />)
+    expect(screen.getByRole('link', { name: /Halfway Found/ })).toHaveAttribute(
+      'href',
+      '/writing/halfway-found'
+    )
+    expect(screen.getByRole('link', { name: /The Hiker/ })).toHaveAttribute(
+      'href',
+      '/writing/the-hiker'
+    )
+  })
+
+  it('renders an outbound link to the Substack', () => {
+    render(<WritingPage />)
+    const substackLink = screen.getByRole('link', { name: 'Subscribe on Substack' })
+    expect(substackLink).toHaveAttribute('href', 'https://crawfordyoung.substack.com/subscribe')
+    expect(substackLink).toHaveAttribute('target', '_blank')
+    expect(substackLink).toHaveAttribute('rel', 'noreferrer')
+  })
+})

--- a/tests/unit/writing-hub.test.tsx
+++ b/tests/unit/writing-hub.test.tsx
@@ -35,10 +35,10 @@ describe('WritingPage', () => {
     )
   })
 
-  it('renders an outbound link to the Substack', () => {
+  it('renders an outbound link to the Substack page itself, not the subscribe form', () => {
     render(<WritingPage />)
-    const substackLink = screen.getByRole('link', { name: 'Subscribe on Substack' })
-    expect(substackLink).toHaveAttribute('href', 'https://crawfordyoung.substack.com/subscribe')
+    const substackLink = screen.getByRole('link', { name: 'Read on Substack' })
+    expect(substackLink).toHaveAttribute('href', 'https://crawfordyoung.substack.com/')
     expect(substackLink).toHaveAttribute('target', '_blank')
     expect(substackLink).toHaveAttribute('rel', 'noreferrer')
   })


### PR DESCRIPTION
## Summary

AdSense W3 — the substantive-content wave. No ad units ship.

- **/writing hub** + three poem collections (*Halfway Found*, *Almost*, *You Can't Halfway Jump*, 10 poems with per-poem anchors) + short story (*The Hiker*)
- **All 8 project pages** rewritten with 300–600-word first-person write-ups (problem → approach → what I'd do differently → what broke); dead ChessBot repo link dropped
- **/about** (~400 words), nav completed to 6 pills
- MDX pipeline (`@next/mdx`), zod registry, explicit content maps (Turbopack constraint), word-floor content tests compiling raw MDX via `@mdx-js/mdx`
- Per-page canonical + full openGraph block on every new page
- Poems render as card panels; GlowCard hover-radius fix (site-wide); Substack card links to the page itself
- README + CLAUDE.md writing conventions documented

## Gates

- vitest 130/130, coverage 100/100/100/100 (58/58, 10/10, 21/21, 50/50)
- e2e 25/25 on :3001; eslint/prettier/tsc clean; build 25 pages SSG
- axe 14/14 runs (7 pages × dark/light, theme class asserted), 0 violations
- Lighthouse a11y 100 / seo 100 all four sampled pages; perf 74–77 vs untouched-home baseline 71 (pre-existing LCP debt, carried); BP 96 = localhost `/_vercel/insights/*` 404s
- User QA passed 2026-07-31 (fact-pass, poem fidelity, titles, presentation)

Gate base: origin/main @ 0563937.

🤖 Generated with [Claude Code](https://claude.com/claude-code)